### PR TITLE
Changes for #71 Changes for filtering based on boundaryType and boundary added

### DIFF
--- a/business-services/egov-hrms/src/main/java/org/egov/hrms/model/Boundary.java
+++ b/business-services/egov-hrms/src/main/java/org/egov/hrms/model/Boundary.java
@@ -1,0 +1,28 @@
+package org.egov.hrms.model;
+
+import java.math.BigInteger;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Boundary {
+	
+	 private int id;
+	 private int boundaryNum;
+	 private String name;
+	 private String localname;
+	 private Double longitude;
+	 private Double latitude;
+	 private String label;
+	 private String code;
+	 private String area;
+	 private List<BigInteger> pincode;
+	 private List<Boundary> children;
+
+}

--- a/business-services/egov-hrms/src/main/java/org/egov/hrms/model/HierarchyType.java
+++ b/business-services/egov-hrms/src/main/java/org/egov/hrms/model/HierarchyType.java
@@ -1,0 +1,12 @@
+package org.egov.hrms.model;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class HierarchyType {
+	
+	private String code;
+    private String name;
+}

--- a/business-services/egov-hrms/src/main/java/org/egov/hrms/model/TenantBoundary.java
+++ b/business-services/egov-hrms/src/main/java/org/egov/hrms/model/TenantBoundary.java
@@ -1,0 +1,14 @@
+package org.egov.hrms.model;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TenantBoundary {
+	
+	 private Boundary boundary;
+	 private HierarchyType hierarchyType;
+
+}
+

--- a/business-services/egov-hrms/src/main/java/org/egov/hrms/repository/EmployeeQueryBuilder.java
+++ b/business-services/egov-hrms/src/main/java/org/egov/hrms/repository/EmployeeQueryBuilder.java
@@ -91,13 +91,12 @@ public class EmployeeQueryBuilder {
 			preparedStmtList.add(criteria.getIsActive());
 		}
 		
-		if(!(StringUtils.isEmpty(criteria.getBoundaryType())) && StringUtils.isEmpty(criteria.getBoundary())) {
-			builder.append(" and jurisdiction.boundarytype = ?");
-			preparedStmtList.add(criteria.getBoundaryType());
-		}
-		else if(!(CollectionUtils.isEmpty(criteria.getValidBoundaryCodes()))) {
+		if(!(CollectionUtils.isEmpty(criteria.getValidBoundaryCodes()))) {
 			builder.append(" and jurisdiction.boundary IN (").append(createQuery(criteria.getValidBoundaryCodes())).append(")");
 			addToPreparedStatement(preparedStmtList, criteria.getValidBoundaryCodes());
+		}else if(!(StringUtils.isEmpty(criteria.getBoundaryType()))) {
+			builder.append(" and jurisdiction.boundarytype = ?");
+			preparedStmtList.add(criteria.getBoundaryType());
 		}
 	}
 	

--- a/business-services/egov-hrms/src/main/java/org/egov/hrms/repository/EmployeeQueryBuilder.java
+++ b/business-services/egov-hrms/src/main/java/org/egov/hrms/repository/EmployeeQueryBuilder.java
@@ -95,8 +95,7 @@ public class EmployeeQueryBuilder {
 			builder.append(" and jurisdiction.boundarytype = ?");
 			preparedStmtList.add(criteria.getBoundaryType());
 		}
-		
-		if(!(CollectionUtils.isEmpty(criteria.getValidBoundaryCodes()))) {
+		else if(!(CollectionUtils.isEmpty(criteria.getValidBoundaryCodes()))) {
 			builder.append(" and jurisdiction.boundary IN (").append(createQuery(criteria.getValidBoundaryCodes())).append(")");
 			addToPreparedStatement(preparedStmtList, criteria.getValidBoundaryCodes());
 		}

--- a/business-services/egov-hrms/src/main/java/org/egov/hrms/repository/EmployeeQueryBuilder.java
+++ b/business-services/egov-hrms/src/main/java/org/egov/hrms/repository/EmployeeQueryBuilder.java
@@ -90,6 +90,16 @@ public class EmployeeQueryBuilder {
 			builder.append(" and employee.active = ?");
 			preparedStmtList.add(criteria.getIsActive());
 		}
+		
+		if(!(StringUtils.isEmpty(criteria.getBoundaryType())) && StringUtils.isEmpty(criteria.getBoundary())) {
+			builder.append(" and jurisdiction.boundarytype = ?");
+			preparedStmtList.add(criteria.getBoundaryType());
+		}
+		
+		if(!(CollectionUtils.isEmpty(criteria.getValidBoundaryCodes()))) {
+			builder.append(" and jurisdiction.boundary IN (").append(createQuery(criteria.getValidBoundaryCodes())).append(")");
+			addToPreparedStatement(preparedStmtList, criteria.getValidBoundaryCodes());
+		}
 	}
 	
 	public String paginationClause(EmployeeSearchCriteria criteria, StringBuilder builder) {

--- a/business-services/egov-hrms/src/main/java/org/egov/hrms/service/EmployeeService.java
+++ b/business-services/egov-hrms/src/main/java/org/egov/hrms/service/EmployeeService.java
@@ -194,6 +194,7 @@ public class EmployeeService {
 		}
 		//checks if above criteria met and result is not  null will check for name search if list of names are given as user search on name is not bulk api
 
+		
 		if(!((!CollectionUtils.isEmpty(criteria.getRoles()) || !StringUtils.isEmpty(criteria.getPhone())) && CollectionUtils.isEmpty(criteria.getUuids()))){
 			if(!CollectionUtils.isEmpty(criteria.getNames())) {
 				List<String> userUUIDs = new ArrayList<>();
@@ -209,6 +210,7 @@ public class EmployeeService {
 					}
 					List<String> uuids = userResponse.getUser().stream().map(User :: getUuid).collect(Collectors.toList());
 					userUUIDs.addAll(uuids);
+						
 				}
 				if(!CollectionUtils.isEmpty(criteria.getUuids()))
 					criteria.setUuids(criteria.getUuids().stream().filter(userUUIDs::contains).collect(Collectors.toList()));
@@ -217,7 +219,6 @@ public class EmployeeService {
 			}
 		}
 		
-		// new logic to get valid list of boundary codes for an employee
 		List<String> validBoundaryCodes = new ArrayList<String>();
 		if (!StringUtils.isEmpty(criteria.getBoundary())){
 			
@@ -240,7 +241,7 @@ public class EmployeeService {
         if(!((!CollectionUtils.isEmpty(criteria.getRoles()) || !CollectionUtils.isEmpty(criteria.getNames()) || !StringUtils.isEmpty(criteria.getPhone())|| !StringUtils.isEmpty(criteria.getBoundaryType())|| !StringUtils.isEmpty(criteria.getBoundaryType())) && CollectionUtils.isEmpty(criteria.getUuids())))
             employees = repository.fetchEmployees(criteria, requestInfo, stateLevelTenantId);
          if(!StringUtils.isEmpty(criteria.getBoundary()))	
-        	 filteredEmployees = filterEmployeesByJurisdiction(employees, validBoundaryCodes);
+        	 filteredEmployees = filterEmployeesByJurisdiction(employees, validBoundaryCodes); //gives employees filtered based on Jurisdiction
          else 
         	 filteredEmployees = employees;
          List<String> uuids = filteredEmployees.stream().map(Employee :: getUuid).collect(Collectors.toList());
@@ -263,7 +264,11 @@ public class EmployeeService {
 	}
 		
 	
-	
+	/* method for  logic to get valid list of boundary codes for an employee
+	 * valid boundaries are for employee in SUN04 - SUN04, B1, Z1, pb.amritsar 
+	 * @param boundary, tenantid
+	 * @return list of all valid boundary codes 
+	 */
 	private List<String> getAllValidBoundaryTypesfromMDMS(RequestInfo requestInfo, String boundary, String tenantId) {
 
 		MdmsResponse responseLoc = mdmsService.fetchMDMSDataLoc(requestInfo, tenantId);
@@ -295,7 +300,9 @@ public class EmployeeService {
 
 		return parentCodes;
 	}
-
+	
+	/* method to find the parent codes for a particular boundary code for eg Locality SUN04 will have parents as 
+	 * Block B1 whose parent is Z1 and the City pb.amritsar */
 	private static List<String> findParentCodes(TenantBoundary[] tenantBoundaries, String targetCode) {
 		Map<String, String> codeToParentMap = new HashMap<>();
 		for (TenantBoundary tenantBoundary : tenantBoundaries) {
@@ -322,6 +329,7 @@ public class EmployeeService {
 		}
 	}
 
+	/* method to get employees filtered based on the jurisdiction starting from bottom level to top level */
 	private static List<Employee> filterEmployeesByJurisdiction(List<Employee> employees, List<String> parentCodes) {
 		 List<Employee> filteredEmployees = new ArrayList<>();
 

--- a/business-services/egov-hrms/src/main/java/org/egov/hrms/service/EmployeeService.java
+++ b/business-services/egov-hrms/src/main/java/org/egov/hrms/service/EmployeeService.java
@@ -236,10 +236,14 @@ public class EmployeeService {
 		
 		
 		List <Employee> employees = new ArrayList<>();
+		List<Employee> filteredEmployees  = new ArrayList<>();
         if(!((!CollectionUtils.isEmpty(criteria.getRoles()) || !CollectionUtils.isEmpty(criteria.getNames()) || !StringUtils.isEmpty(criteria.getPhone())|| !StringUtils.isEmpty(criteria.getBoundaryType())|| !StringUtils.isEmpty(criteria.getBoundaryType())) && CollectionUtils.isEmpty(criteria.getUuids())))
             employees = repository.fetchEmployees(criteria, requestInfo, stateLevelTenantId);
-        	List<Employee> filteredEmployees = filterEmployeesByJurisdiction(employees, validBoundaryCodes);
-        List<String> uuids = filteredEmployees.stream().map(Employee :: getUuid).collect(Collectors.toList());
+         if(!StringUtils.isEmpty(criteria.getBoundary()))	
+        	 filteredEmployees = filterEmployeesByJurisdiction(employees, validBoundaryCodes);
+         else 
+        	 filteredEmployees = employees;
+         List<String> uuids = filteredEmployees.stream().map(Employee :: getUuid).collect(Collectors.toList());
 		if(!CollectionUtils.isEmpty(uuids)){
             Map<String, Object> UserSearchCriteria = new HashMap<>();
             UserSearchCriteria.put(HRMSConstants.HRMS_USER_SEARCH_CRITERA_UUID,uuids);
@@ -319,14 +323,7 @@ public class EmployeeService {
 	}
 
 	private static List<Employee> filterEmployeesByJurisdiction(List<Employee> employees, List<String> parentCodes) {
-		List<Employee> filteredEmployees = new ArrayList<>();
-
-		// Filter employees at the target code level
-		for (Employee employee : employees) {
-			if (hasJurisdiction(employee, parentCodes.get(0))) {
-				filteredEmployees.add(employee);
-			}
-		}
+		 List<Employee> filteredEmployees = new ArrayList<>();
 
 		// If no employees at target code level, progressively go up to parent codes
 		if (filteredEmployees.isEmpty()) {
@@ -342,8 +339,7 @@ public class EmployeeService {
 			}
 		}
 
-		return filteredEmployees;
-	}
+	        return filteredEmployees;	}
 
 	private static boolean hasJurisdiction(Employee employee, String jurisdictionCode) {
 		for (Jurisdiction jurisdiction : employee.getJurisdictions()) {

--- a/business-services/egov-hrms/src/main/java/org/egov/hrms/service/EmployeeService.java
+++ b/business-services/egov-hrms/src/main/java/org/egov/hrms/service/EmployeeService.java
@@ -238,7 +238,7 @@ public class EmployeeService {
 		
 		List <Employee> employees = new ArrayList<>();
 		List<Employee> filteredEmployees  = new ArrayList<>();
-        if(!((!CollectionUtils.isEmpty(criteria.getRoles()) || !CollectionUtils.isEmpty(criteria.getNames()) || !StringUtils.isEmpty(criteria.getPhone())|| !StringUtils.isEmpty(criteria.getBoundaryType())|| !StringUtils.isEmpty(criteria.getBoundaryType())) && CollectionUtils.isEmpty(criteria.getUuids())))
+        if(!((!CollectionUtils.isEmpty(criteria.getRoles()) || !CollectionUtils.isEmpty(criteria.getNames()) || !StringUtils.isEmpty(criteria.getPhone())|| !StringUtils.isEmpty(criteria.getBoundary())|| !StringUtils.isEmpty(criteria.getBoundaryType())) && CollectionUtils.isEmpty(criteria.getUuids())))
             employees = repository.fetchEmployees(criteria, requestInfo, stateLevelTenantId);
          if(!StringUtils.isEmpty(criteria.getBoundary()))	
         	 filteredEmployees = filterEmployeesByJurisdiction(employees, validBoundaryCodes); //gives employees filtered based on Jurisdiction

--- a/business-services/egov-hrms/src/main/java/org/egov/hrms/web/contract/EmployeeRequest.java
+++ b/business-services/egov-hrms/src/main/java/org/egov/hrms/web/contract/EmployeeRequest.java
@@ -72,5 +72,8 @@ public class EmployeeRequest {
 	@NotEmpty
 	@JsonProperty("Employees")
 	private List<Employee> employees;
+	
+	@Builder.Default
+	private Boolean isJurisdictionEnabled = false;
 
 }

--- a/business-services/egov-hrms/src/main/java/org/egov/hrms/web/contract/EmployeeSearchCriteria.java
+++ b/business-services/egov-hrms/src/main/java/org/egov/hrms/web/contract/EmployeeSearchCriteria.java
@@ -47,6 +47,12 @@ public class EmployeeSearchCriteria {
 	
 	public Boolean isActive;
 
+	public String boundaryType;
+	
+	public String boundary;
+	
+	public List<String> validBoundaryCodes;
+	
 	@Size(max = 250)
 	public String tenantId;
 	
@@ -62,7 +68,8 @@ public class EmployeeSearchCriteria {
 				&& CollectionUtils.isEmpty(criteria.getIds()) && CollectionUtils.isEmpty(criteria.getEmployeestatuses())
 				&& CollectionUtils.isEmpty(criteria.getEmployeetypes()) && CollectionUtils.isEmpty(criteria.getUuids())
 				&& CollectionUtils.isEmpty(criteria.getPositions()) && StringUtils.isEmpty(criteria.getTenantId())
-				&& CollectionUtils.isEmpty(criteria.getRoles()) && null == criteria.getAsOnDate()) {
+				&& CollectionUtils.isEmpty(criteria.getRoles()) && null == criteria.getAsOnDate()
+				&& StringUtils.isEmpty(criteria.getBoundaryType())) {
 			return true;
 		}else {
 			return false;

--- a/business-services/egov-hrms/src/main/java/org/egov/hrms/web/validator/EmployeeValidator.java
+++ b/business-services/egov-hrms/src/main/java/org/egov/hrms/web/validator/EmployeeValidator.java
@@ -63,7 +63,7 @@ public class EmployeeValidator {
 		Map<String, List<String>> boundaryMap = getBoundaryList(request.getRequestInfo(),request.getEmployees().get(0));
 		Map<String, List<String>> mdmsData = mdmsService.getMDMSData(request.getRequestInfo(), request.getEmployees().get(0).getTenantId());
 		if(!CollectionUtils.isEmpty(mdmsData.keySet())){
-			request.getEmployees().stream().forEach(employee -> validateMdmsData(employee, errorMap, mdmsData,boundaryMap));
+			request.getEmployees().stream().forEach(employee -> validateMdmsData(employee, errorMap, mdmsData,boundaryMap,request.getIsJurisdictionEnabled()));
 		}
 		if(!CollectionUtils.isEmpty(errorMap.keySet()))
 			throw new CustomException(errorMap);
@@ -236,13 +236,16 @@ public class EmployeeValidator {
      * @param errorMap
      * @param mdmsData
      */
-	private void validateMdmsData(Employee employee, Map<String, String> errorMap, Map<String, List<String>> mdmsData, Map<String, List<String>> boundaryMap) {
+	private void validateMdmsData(Employee employee, Map<String, String> errorMap, Map<String, List<String>> mdmsData, Map<String, List<String>> boundaryMap , boolean isJurisdictionEnabled) {
 		validateEmployee(employee, errorMap, mdmsData);
 		validateAssignments(employee, errorMap, mdmsData);
 		validateServiceHistory(employee, errorMap, mdmsData);
-		validateJurisdicton(employee, errorMap, mdmsData, boundaryMap);
 		validateEducationalDetails(employee, errorMap, mdmsData);
 		validateDepartmentalTest(employee, errorMap, mdmsData);
+		
+		if (!isJurisdictionEnabled) {
+	        validateJurisdicton(employee, errorMap, mdmsData, boundaryMap);
+	    }
 	}
 
 
@@ -570,7 +573,7 @@ public class EmployeeValidator {
 				else
 					errorMap.put(ErrorConstants.HRMS_UPDATE_EMPLOYEE_NOT_EXIST_CODE, ErrorConstants.HRMS_UPDATE_EMPLOYEE_NOT_EXIST_MSG);
 			}
-			validateMdmsData(employee, errorMap, mdmsData,boundaryMap);
+			validateMdmsData(employee, errorMap, mdmsData,boundaryMap, request.getIsJurisdictionEnabled());
 		}
 		if(!CollectionUtils.isEmpty(errorMap.keySet())) {	
 			throw new CustomException(errorMap);

--- a/business-services/egov-hrms/src/main/java/org/egov/hrms/web/validator/EmployeeValidator.java
+++ b/business-services/egov-hrms/src/main/java/org/egov/hrms/web/validator/EmployeeValidator.java
@@ -75,7 +75,7 @@ public class EmployeeValidator {
 		Map<String, List<String>> masterData = new HashMap<>();
 		if(!CollectionUtils.isEmpty(employee.getJurisdictions())){
 			for(Jurisdiction jurisdiction: employee.getJurisdictions()){
-				if(!boundarytList.contains(jurisdiction.getTenantId()))
+				if(!boundarytList.contains(jurisdiction.getBoundary()))
 					boundarytList.add(jurisdiction.getTenantId());
 			}
 			if(CollectionUtils.isEmpty(boundarytList))

--- a/business-services/egov-hrms/src/main/java/org/egov/hrms/web/validator/EmployeeValidator.java
+++ b/business-services/egov-hrms/src/main/java/org/egov/hrms/web/validator/EmployeeValidator.java
@@ -76,7 +76,7 @@ public class EmployeeValidator {
 		if(!CollectionUtils.isEmpty(employee.getJurisdictions())){
 			for(Jurisdiction jurisdiction: employee.getJurisdictions()){
 				if(!boundarytList.contains(jurisdiction.getBoundary()))
-					boundarytList.add(jurisdiction.getTenantId());
+					boundarytList.add(jurisdiction.getBoundary());
 			}
 			if(CollectionUtils.isEmpty(boundarytList))
 				boundarytList.add(employee.getTenantId());

--- a/business-services/egov-hrms/src/main/java/org/egov/hrms/web/validator/EmployeeValidator.java
+++ b/business-services/egov-hrms/src/main/java/org/egov/hrms/web/validator/EmployeeValidator.java
@@ -75,8 +75,8 @@ public class EmployeeValidator {
 		Map<String, List<String>> masterData = new HashMap<>();
 		if(!CollectionUtils.isEmpty(employee.getJurisdictions())){
 			for(Jurisdiction jurisdiction: employee.getJurisdictions()){
-				if(!boundarytList.contains(jurisdiction.getBoundary()))
-					boundarytList.add(jurisdiction.getBoundary());
+				if(!boundarytList.contains(jurisdiction.getTenantId()))
+					boundarytList.add(jurisdiction.getTenantId());
 			}
 			if(CollectionUtils.isEmpty(boundarytList))
 				boundarytList.add(employee.getTenantId());


### PR DESCRIPTION
I have made changes to address the following -

in EmployeeSearchCriteria added the following 
- boundaryType - to be able to send boundaryType ( locality, city, block, zone etc. )
- boundary - to be able to send the codes like ( pb.amritsar, B1, Z1, SUN04 etc. )

In employeeValidator for creating employee changed getBoundary() to getTenantId() as now both will be different.

In Employee service added logic to get all parentCodes for a particular boundary code in which an employee can have access to for a particular application. For eg - an application in B1 ( which is a block ) can have an employee from B1 or Z1 or pb.amritsar take action on an application

created Models for tenantBoundary, Boundary, HierarchyType so that a Tree can be created to parse in heirarchical way

in queryBuilder added conditions to check for jurisdiction.boundary & jurisdiction.boundaryType

It checks for boundaryType only when boundary criteria is empty 