### PR TITLE
Fixed capital letters in tenant management

### DIFF
--- a/build/build-config.yml
+++ b/build/build-config.yml
@@ -464,10 +464,10 @@ config:
   - name: "builds/Digit-Core/core-services/TenantManagement"
     build:
       - work-dir: "core-services/TenantManagement"
-        image-name: "TenantManagement"
+        image-name: "tenant-management"
         dockerfile: "build/maven/Dockerfile"
       - work-dir: "core-services/TenantManagement/src/main/resources/db"
-        image-name: "TenantManagement-db"
+        image-name: "tenant-management-db"
   
   # PGR AI chatbot
   - name: "builds/Digit-Core/accelerators/pgr-ai-chatbot"


### PR DESCRIPTION
removed caps from image name in tenant management service build config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Standardized Docker image naming conventions for the TenantManagement service to use lowercase, improving compatibility across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->