### PR TITLE
fix(workflow): derive state tenant dynamically instead of hardcoded config

### DIFF
--- a/core-services/egov-workflow-v2/src/main/java/org/egov/wf/repository/BusinessServiceRepository.java
+++ b/core-services/egov-workflow-v2/src/main/java/org/egov/wf/repository/BusinessServiceRepository.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
+import org.egov.common.utils.MultiStateInstanceUtil;
 import org.egov.wf.config.WorkflowConfig;
 import org.egov.wf.repository.querybuilder.BusinessServiceQueryBuilder;
 import org.egov.wf.repository.rowmapper.BusinessServiceRowMapper;
@@ -41,6 +42,9 @@ public class BusinessServiceRepository {
     
     @Autowired
     private  WorkflowUtil util;
+
+    @Autowired
+    private MultiStateInstanceUtil centralInstanceUtil;
 
 
     @Autowired
@@ -186,13 +190,19 @@ public class BusinessServiceRepository {
                // throw new CustomException("INVALID_MDMS_CONFIG","The master data is missing for businessService: "+code);
             }
 
+            // Derive whether this definition is at state level by checking if its
+            // tenantId equals its own root (e.g., "pg" == root of "pg", so it's state-level).
+            // This replaces the previous comparison against a hardcoded config value,
+            // allowing workflow definitions under any state root to be recognized.
+            boolean isAtStateLevel = centralInstanceUtil.isTenantIdStateLevel(tenantId);
+
             if(isStatelevel){
-                if(tenantId.equalsIgnoreCase(config.getStateLevelTenantId())){
+                if(isAtStateLevel){
                     filteredBusinessService.add(businessService);
                 }
             }
             else {
-                if(!tenantId.equalsIgnoreCase(config.getStateLevelTenantId())){
+                if(!isAtStateLevel){
                     filteredBusinessService.add(businessService);
                 }
             }

--- a/core-services/egov-workflow-v2/src/main/java/org/egov/wf/repository/V1/BusinessServiceRepositoryV1.java
+++ b/core-services/egov-workflow-v2/src/main/java/org/egov/wf/repository/V1/BusinessServiceRepositoryV1.java
@@ -203,13 +203,15 @@ public class BusinessServiceRepositoryV1 {
                 // throw new CustomException("INVALID_MDMS_CONFIG","The master data is missing for businessService: "+code);
             }
 
+            boolean isAtStateLevel = multiStateInstanceUtil.isTenantIdStateLevel(tenantId);
+
             if(isStatelevel){
-                if(tenantId.equalsIgnoreCase(config.getStateLevelTenantId())){
+                if(isAtStateLevel){
                     filteredBusinessService.add(businessService);
                 }
             }
             else {
-                if(!tenantId.equalsIgnoreCase(config.getStateLevelTenantId())){
+                if(!isAtStateLevel){
                     filteredBusinessService.add(businessService);
                 }
             }

--- a/core-services/egov-workflow-v2/src/main/java/org/egov/wf/service/MDMSService.java
+++ b/core-services/egov-workflow-v2/src/main/java/org/egov/wf/service/MDMSService.java
@@ -82,10 +82,25 @@ public class MDMSService {
 
 
     /**
-     * Calls MDMS service to fetch master data
+     * Calls MDMS service to fetch master data.
+     * Derives the state-level tenant from the provided tenantId
+     * so that workflows under any state root are supported.
      * @param requestInfo
+     * @param tenantId tenantId from the request (e.g. "pg.citya" or "statea.city1")
      * @return
      */
+    public Object mDMSCall(RequestInfo requestInfo, String tenantId){
+        String stateTenant = centralInstanceUtil.getStateLevelTenant(tenantId);
+        MdmsCriteriaReq mdmsCriteriaReq = getMDMSRequest(requestInfo, stateTenant);
+        Object result = serviceRequestRepository.fetchResult(getMdmsSearchUrl(), mdmsCriteriaReq);
+        return result;
+    }
+
+    /**
+     * @deprecated Use {@link #mDMSCall(RequestInfo, String)} with an explicit tenantId.
+     * Falls back to the configured state.level.tenant.id for backward compatibility.
+     */
+    @Deprecated
     public Object mDMSCall(RequestInfo requestInfo){
         MdmsCriteriaReq mdmsCriteriaReq = getMDMSRequest(requestInfo,workflowConfig.getStateLevelTenantId());
         Object result = serviceRequestRepository.fetchResult(getMdmsSearchUrl(), mdmsCriteriaReq);


### PR DESCRIPTION
## Summary

- `BusinessServiceRepository` and `BusinessServiceRepositoryV1`: replace hardcoded `config.getStateLevelTenantId()` comparison with `MultiStateInstanceUtil.isTenantIdStateLevel()` to dynamically determine if a workflow definition is at the state level
- `MDMSService`: add tenant-aware `mDMSCall(RequestInfo, String)` overload that derives the state root via `MultiStateInstanceUtil.getStateLevelTenant()`; deprecate the no-arg version (kept for backward compat in `EscalationService`)

## Problem

`egov-workflow-v2` uses a hardcoded `state.level.tenant.id` config property (set via `STATE_LEVEL_TENANT_ID` env var, typically `pg`) for:
1. Filtering which workflow definitions are "state-level" vs "city-level" in `filterBusinessServices()`
2. MDMS master data queries in `MDMSService`

This means workflow definitions stored under any state root **other than** the configured one are invisible. New tenant hierarchies (e.g., `statea.city1`) cannot use PGR or any other workflow-driven service without changing the env var and restarting.

Full problem statement: https://gist.github.com/ChakshuGautam/6cacb1b6ac5d2db14fac1c5789680f27

## Approach

The shared library `MultiStateInstanceUtil` (already imported in these files) has methods that derive the state root dynamically from any tenant ID:
- `isTenantIdStateLevel("pg")` → `true`, `isTenantIdStateLevel("pg.citya")` → `false`  
- `getStateLevelTenant("pg.citya")` → `"pg"`, `getStateLevelTenant("statea.city1")` → `"statea"`

This PR replaces the hardcoded comparisons with these dynamic utility methods. The `state.level.tenant.id` config property is retained as a fallback for the escalation batch job (which lacks request-scoped tenant context).

## Test plan

- [ ] Verify existing PGR workflow lifecycle (CREATE → ASSIGN → RESOLVE → RATE) still works on `pg.citya`
- [ ] Verify workflow definitions under a second state root (e.g., `statea`) are recognized
- [ ] Verify escalation service still works (uses deprecated no-arg `mDMSCall`)
- [ ] `mvn compile` passes cleanly