### PR TITLE
fix(boundary-service): fix tenant filtering and tree assembly in relationship search

### DIFF
--- a/core-services/boundary-service/src/main/java/digit/repository/querybuilder/BoundaryRelationshipQueryBuilder.java
+++ b/core-services/boundary-service/src/main/java/digit/repository/querybuilder/BoundaryRelationshipQueryBuilder.java
@@ -57,10 +57,9 @@ public class BoundaryRelationshipQueryBuilder {
             }
         }
 
-        if(boundaryRelationshipSearchCriteria.getIsSearchForRootNode()) {
-            QueryUtil.addClauseIfRequired(builder, preparedStmtList);
-            builder.append(" parent IS NULL ");
-        }
+        // When isSearchForRootNode is true, fetch ALL nodes for the tenant+hierarchy
+        // so the enricher can build the full tree. Do NOT restrict to parent IS NULL,
+        // as that returns only root nodes with no children to assemble.
 
         if(!CollectionUtils.isEmpty(boundaryRelationshipSearchCriteria.getCurrentBoundaryCodes())) {
             QueryUtil.addClauseIfRequired(builder, preparedStmtList);

--- a/core-services/boundary-service/src/main/java/digit/web/controllers/BoundaryRelationshipController.java
+++ b/core-services/boundary-service/src/main/java/digit/web/controllers/BoundaryRelationshipController.java
@@ -4,7 +4,6 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import digit.service.BoundaryRelationshipService;
 import digit.web.models.*;
-import org.egov.common.contract.request.RequestInfo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -35,13 +34,13 @@ public class BoundaryRelationshipController {
 
     /**
      * Request handler for serving boundary relationships search request.
-     * @param boundaryRelationshipSearchCriteria
-     * @param requestInfo
+     * @param body wrapper containing RequestInfo and BoundaryRelationshipSearchCriteria
      * @return
      */
     @RequestMapping(value = "/_search", method = RequestMethod.POST)
-    public ResponseEntity<BoundarySearchResponse> search(@Valid @ModelAttribute BoundaryRelationshipSearchCriteria boundaryRelationshipSearchCriteria, @RequestBody RequestInfo requestInfo) {
-        BoundarySearchResponse boundarySearchResponse = boundaryRelationshipService.getBoundaryRelationships(boundaryRelationshipSearchCriteria, requestInfo);
+    public ResponseEntity<BoundarySearchResponse> search(@Valid @RequestBody BoundaryRelationshipSearchRequest body) {
+        BoundarySearchResponse boundarySearchResponse = boundaryRelationshipService.getBoundaryRelationships(
+                body.getBoundaryRelationshipSearchCriteria(), body.getRequestInfo());
         return new ResponseEntity<>(boundarySearchResponse, HttpStatus.OK);
     }
 

--- a/core-services/boundary-service/src/main/java/digit/web/models/BoundaryRelationshipSearchRequest.java
+++ b/core-services/boundary-service/src/main/java/digit/web/models/BoundaryRelationshipSearchRequest.java
@@ -1,0 +1,32 @@
+package digit.web.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.egov.common.contract.request.RequestInfo;
+import org.springframework.validation.annotation.Validated;
+
+import jakarta.validation.Valid;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Data;
+import lombok.Builder;
+
+/**
+ * Wrapper request for boundary relationship search — contains RequestInfo and search criteria.
+ */
+@Validated
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class BoundaryRelationshipSearchRequest {
+
+    @JsonProperty("RequestInfo")
+    @Valid
+    private RequestInfo requestInfo = null;
+
+    @JsonProperty("BoundaryRelationship")
+    @Valid
+    private BoundaryRelationshipSearchCriteria boundaryRelationshipSearchCriteria = null;
+
+}


### PR DESCRIPTION
## Summary

- **Controller bug**: `boundary-relationships/_search` used `@ModelAttribute` for `BoundaryRelationshipSearchCriteria`, which reads query params/form data — not JSON POST body. All filter fields (`tenantId`, `hierarchyType`, `codes`, etc.) were always `null`, so every search returned **all boundaries across all tenants globally**. Fixed by introducing a `BoundaryRelationshipSearchRequest` wrapper class with `@RequestBody`.

- **Query builder bug**: When `isSearchForRootNode=true`, the query appended `parent IS NULL`, returning only root-level nodes with no children. The `BoundaryRelationshipEnricher.getSeedBoundaryList()` needs ALL nodes for the tenant+hierarchy to build the tree recursively. Fixed by removing the `parent IS NULL` clause — the enricher determines the root from hierarchy level order.

## Files Changed

| File | Change |
|------|--------|
| `BoundaryRelationshipController.java` | Replace `@ModelAttribute` + `@RequestBody RequestInfo` with single `@RequestBody BoundaryRelationshipSearchRequest` |
| `BoundaryRelationshipSearchRequest.java` | **New** — wrapper model with `RequestInfo` + `BoundaryRelationshipSearchCriteria` |
| `BoundaryRelationshipQueryBuilder.java` | Remove `parent IS NULL` clause when `isSearchForRootNode=true` |

## Test plan

- [x] Deployed patched JAR to running boundary-service container
- [x] Verified `validate_boundary` for `mz.chimoio` returns correct 49-node tree (Country → State → 12 Districts → 34 Sub-Districts)
- [x] Verified tenant filtering works — only `mz.chimoio` boundaries returned, not all tenants
- [x] Verified `_create` and `_update` endpoints still work (unchanged)
- [x] Verified `pg.citya` boundary search still returns correct tree

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Boundary relationship search now returns complete hierarchical tree data instead of limiting results to root nodes.

* **Refactor**
  * Search endpoint updated with unified request wrapper format for simplified API integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->