### PR TITLE
Extract locale from request and use it for localisation instead of using hardcoded locale

### DIFF
--- a/core-services/user-otp/src/main/java/org/egov/persistence/repository/OtpEmailRepository.java
+++ b/core-services/user-otp/src/main/java/org/egov/persistence/repository/OtpEmailRepository.java
@@ -43,6 +43,9 @@ public class OtpEmailRepository {
 	
 	@Value("${egov.localization.default.locale:en_IN}")
     private String defaultLocale;
+	
+	@Value("${egov.localization.module}")
+    private String localizationModule;
 
     @Autowired
     public OtpEmailRepository(CustomKafkaTemplate<String, EmailRequest> kafkaTemplate,
@@ -85,7 +88,7 @@ public class OtpEmailRepository {
 	private String getMessages(OtpRequest otpRequest, String localizationKey){
 		String tenantId = getRequiredTenantId(otpRequest.getTenantId());
 		String locale = getLocale(otpRequest);
-		Map<String, String> localisedMessages = localizationService.getLocalisedMessages(tenantId, locale, "egov-user");
+		Map<String, String> localisedMessages = localizationService.getLocalisedMessages(tenantId, locale, localizationModule);
 		if (localisedMessages.isEmpty()) {
 			log.info("Localization Service didn't return any Subject so using default...");
 			localisedMessages.put(LOCALIZATION_KEY_PWD_RESET_SUBJECT_EMAIL, "Password Reset");

--- a/core-services/user-otp/src/main/java/org/egov/persistence/repository/OtpEmailRepository.java
+++ b/core-services/user-otp/src/main/java/org/egov/persistence/repository/OtpEmailRepository.java
@@ -40,6 +40,9 @@ public class OtpEmailRepository {
 
 	@Autowired
 	private MultiStateInstanceUtil centralInstanceUtil;
+	
+	@Value("${egov.localization.default.locale:en_IN}")
+    private String defaultLocale;
 
     @Autowired
     public OtpEmailRepository(CustomKafkaTemplate<String, EmailRequest> kafkaTemplate,
@@ -74,7 +77,7 @@ public class OtpEmailRepository {
 			locale = otpRequest.getRequestInfo().getMsgId().split("|")[1];
 		}
 		else {
-			locale = "en_IN";
+			locale = defaultLocale;
 		}
 		return locale;
 	}

--- a/core-services/user-otp/src/main/java/org/egov/persistence/repository/OtpSMSRepository.java
+++ b/core-services/user-otp/src/main/java/org/egov/persistence/repository/OtpSMSRepository.java
@@ -42,6 +42,9 @@ public class OtpSMSRepository {
     
     @Value("${egov.localization.default.locale:en_IN}")
     private String defaultLocale;
+    
+    @Value("${egov.localization.module}")
+    private String localizationModule;
 
     @Autowired
     public OtpSMSRepository(CustomKafkaTemplate<String, SMSRequest> kafkaTemplate,
@@ -80,7 +83,7 @@ public class OtpSMSRepository {
             }
         }
 
-        Map<String, String> localisedMsgs = localizationService.getLocalisedMessages(tenantId, locale, "egov-user");
+        Map<String, String> localisedMsgs = localizationService.getLocalisedMessages(tenantId, locale, localizationModule);
         if (localisedMsgs.isEmpty()) {
             log.info("Localization Service didn't return any msgs so using default...");
             localisedMsgs.put(LOCALIZATION_KEY_REGISTER_SMS, "Dear Citizen, Your OTP to complete your DIGIT Registration is %s.");

--- a/core-services/user-otp/src/main/java/org/egov/persistence/repository/OtpSMSRepository.java
+++ b/core-services/user-otp/src/main/java/org/egov/persistence/repository/OtpSMSRepository.java
@@ -39,6 +39,9 @@ public class OtpSMSRepository {
 
     @Autowired
     private MultiStateInstanceUtil centralInstanceUtil;
+    
+    @Value("${egov.localization.default.locale:en_IN}")
+    private String defaultLocale;
 
     @Autowired
     public OtpSMSRepository(CustomKafkaTemplate<String, SMSRequest> kafkaTemplate,
@@ -62,10 +65,25 @@ public class OtpSMSRepository {
 
     private String getMessageFormat(OtpRequest otpRequest) {
         String tenantId = getRequiredTenantId(otpRequest.getTenantId());
-        Map<String, String> localisedMsgs = localizationService.getLocalisedMessages(tenantId, "en_IN", "egov-user");
+        String locale = defaultLocale;
+
+        if (otpRequest.getRequestInfo() != null 
+                && otpRequest.getRequestInfo().getMsgId() != null) {
+
+            String msgId = otpRequest.getRequestInfo().getMsgId();
+
+            if (msgId.contains("|")) {
+                String[] parts = msgId.split("\\|");
+                if (parts.length > 1 && parts[1] != null && !parts[1].isEmpty()) {
+                    locale = parts[1];
+                }
+            }
+        }
+
+        Map<String, String> localisedMsgs = localizationService.getLocalisedMessages(tenantId, locale, "egov-user");
         if (localisedMsgs.isEmpty()) {
             log.info("Localization Service didn't return any msgs so using default...");
-            localisedMsgs.put(LOCALIZATION_KEY_REGISTER_SMS, "Dear Citizen, Your OTP to complete your mSeva Registration is %s.");
+            localisedMsgs.put(LOCALIZATION_KEY_REGISTER_SMS, "Dear Citizen, Your OTP to complete your DIGIT Registration is %s.");
             localisedMsgs.put(LOCALIZATION_KEY_LOGIN_SMS, "Dear Citizen, Your Login OTP is %s.");
             localisedMsgs.put(LOCALIZATION_KEY_PWD_RESET_SMS, "Dear Citizen, Your OTP for recovering password is %s.");
         }

--- a/core-services/user-otp/src/main/resources/application.properties
+++ b/core-services/user-otp/src/main/resources/application.properties
@@ -21,3 +21,4 @@ egov.localisation.tenantid.strip.suffix.count=1
 
 
 #spring.kafka.producer.properties.spring.json.add.type.headers=false
+egov.localization.default.locale=en_IN

--- a/core-services/user-otp/src/main/resources/application.properties
+++ b/core-services/user-otp/src/main/resources/application.properties
@@ -22,3 +22,4 @@ egov.localisation.tenantid.strip.suffix.count=1
 
 #spring.kafka.producer.properties.spring.json.add.type.headers=false
 egov.localization.default.locale=en_IN
+egov.localization.module=egov-user


### PR DESCRIPTION
- Extract locale from RequestInfo.msgId
- Fallback to default locale from application properties when msgId is null

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email and SMS localization are now configurable, including support for deriving locale from message metadata for per-request localization.
  * SMS fallback content updated to use current branding ("DIGIT Registration").

* **Configuration**
  * New properties expose default locale and localization module to customize localized user communications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->