### PR TITLE
[codex] Harden build workflow input handling

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,10 +63,6 @@ on:
 permissions:
   contents: read
 
-env:
-  DOCKER_USERNAME: ${{ vars.DOCKER_USERNAME }}
-  DOCKER_PASSWORD: ${{ secrets.DOCKER_ACCESS_TOKEN }}
-
 jobs:
   resolve-config:
     runs-on: ubuntu-latest
@@ -86,8 +82,9 @@ jobs:
 
       - name: Determine Dockerfile path from build-config.yml
         id: pick_dockerfile
+        env:
+          SERVICE: ${{ github.event.inputs.service }}
         run: |
-          SERVICE="${{ github.event.inputs.service }}"
           DEFAULT_DOCKERFILE="build/maven/Dockerfile"
 
           echo "Looking for service '$SERVICE' in build-config.yml..."
@@ -134,8 +131,11 @@ jobs:
 
       - name: Check for DB folder
         id: check-db-folder
+        env:
+          SERVICE: ${{ github.event.inputs.service }}
+          SERVICE_FOLDER: ${{ github.event.inputs.service_folder }}
         run: |
-          BASE_PATH="${{ github.event.inputs.service_folder }}/${{ github.event.inputs.service }}"
+          BASE_PATH="${SERVICE_FOLDER}/${SERVICE}"
       
           if [ -d "$BASE_PATH/src/main/resources/db" ]; then
             echo "folder_exists=true" >> "$GITHUB_OUTPUT"
@@ -155,8 +155,8 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
         with:
-          username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ env.DOCKER_PASSWORD }}
+          username: ${{ vars.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
       - name: Build & push ${{ matrix.arch }} image
         id: build_push_app
@@ -191,37 +191,45 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
         with:
-          username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ env.DOCKER_PASSWORD }}
+          username: ${{ vars.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
       - name: Create & push multi-arch manifest (application)
+        env:
+          SERVICE: ${{ github.event.inputs.service }}
+          TAG: ${{ needs.resolve-config.outputs.tag }}
         run: |
           docker buildx imagetools create \
-            --tag egovio/${{ github.event.inputs.service }}:${{ needs.resolve-config.outputs.tag }} \
-            egovio/${{ github.event.inputs.service }}:${{ needs.resolve-config.outputs.tag }}-amd64 \
-            egovio/${{ github.event.inputs.service }}:${{ needs.resolve-config.outputs.tag }}-arm64
+            --tag "egovio/${SERVICE}:${TAG}" \
+            "egovio/${SERVICE}:${TAG}-amd64" \
+            "egovio/${SERVICE}:${TAG}-arm64"
 
       - name: Create & push multi-arch manifest (database)
         if: ${{ needs.build-matrix.outputs.db_folder_exists == 'true' }}
+        env:
+          SERVICE: ${{ github.event.inputs.service }}
+          TAG: ${{ needs.resolve-config.outputs.tag }}
         run: |
           docker buildx imagetools create \
-            --tag egovio/${{ github.event.inputs.service }}-db:${{ needs.resolve-config.outputs.tag }} \
-            egovio/${{ github.event.inputs.service }}-db:${{ needs.resolve-config.outputs.tag }}-amd64 \
-            egovio/${{ github.event.inputs.service }}-db:${{ needs.resolve-config.outputs.tag }}-arm64
+            --tag "egovio/${SERVICE}-db:${TAG}" \
+            "egovio/${SERVICE}-db:${TAG}-amd64" \
+            "egovio/${SERVICE}-db:${TAG}-arm64"
 
       - name: Add all image tags to GitHub summary
         env:
           DB_EXISTS: ${{ needs.build-matrix.outputs.db_folder_exists }}
+          SERVICE: ${{ github.event.inputs.service }}
+          TAG: ${{ needs.resolve-config.outputs.tag }}
         run: |
           echo "## App Docker images" >> $GITHUB_STEP_SUMMARY
-          echo "- \`egovio/${{ github.event.inputs.service }}:${{ needs.resolve-config.outputs.tag }}-amd64\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`egovio/${{ github.event.inputs.service }}:${{ needs.resolve-config.outputs.tag }}-arm64\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **multi‑arch** \`egovio/${{ github.event.inputs.service }}:${{ needs.resolve-config.outputs.tag }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`egovio/${SERVICE}:${TAG}-amd64\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`egovio/${SERVICE}:${TAG}-arm64\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **multi‑arch** \`egovio/${SERVICE}:${TAG}\`" >> $GITHUB_STEP_SUMMARY
 
           if [ "$DB_EXISTS" = "true" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "## DB Docker images" >> $GITHUB_STEP_SUMMARY
-            echo "- \`egovio/${{ github.event.inputs.service }}-db:${{ needs.resolve-config.outputs.tag }}-amd64\`" >> $GITHUB_STEP_SUMMARY
-            echo "- \`egovio/${{ github.event.inputs.service }}-db:${{ needs.resolve-config.outputs.tag }}-arm64\`" >> $GITHUB_STEP_SUMMARY
-            echo "- **multi‑arch** \`egovio/${{ github.event.inputs.service }}-db:${{ needs.resolve-config.outputs.tag }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "- \`egovio/${SERVICE}-db:${TAG}-amd64\`" >> $GITHUB_STEP_SUMMARY
+            echo "- \`egovio/${SERVICE}-db:${TAG}-arm64\`" >> $GITHUB_STEP_SUMMARY
+            echo "- **multi‑arch** \`egovio/${SERVICE}-db:${TAG}\`" >> $GITHUB_STEP_SUMMARY
           fi


### PR DESCRIPTION
## What changed
This PR hardens the `Build Pipeline` workflow against command injection from `workflow_dispatch` inputs.

## Why
The workflow was interpolating `${{ github.event.inputs.service }}` and `${{ github.event.inputs.service_folder }}` directly inside `run:` shell scripts. GitHub expands those expressions before the shell executes, so a crafted input could be interpreted as shell code.

## Fix
- Move dispatch inputs into step-level `env` variables before shell execution
- Use quoted shell variables such as `"$SERVICE"` and `"$SERVICE_FOLDER"` in the affected `run:` steps
- Remove workflow-wide Docker Hub credential env vars and scope the secret to the login steps that need it

## Impact
Build behavior should remain the same, but the workflow no longer relies on direct expression interpolation inside shell commands.

## Validation
- Parsed `.github/workflows/build.yaml` successfully with Ruby YAML
- Reviewed the workflow to ensure shell `run:` blocks no longer inline `github.event.inputs.*` values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration for improved credential management and environment variable handling.

---

**Note:** This release contains internal infrastructure updates with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->