### PR TITLE
[codex] Revert PR #1292 scorecard PAT change

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,6 +1,7 @@
 # This workflow uses actions that are not certified by GitHub. They are provided
 # by a third-party and are governed by separate terms of service, privacy
 # policy, and support documentation.
+
 name: Scorecard supply-chain security
 on:
   # For Branch-Protection check. Only the default branch is supported. See
@@ -12,8 +13,10 @@ on:
     - cron: '45 1 * * 4'
   push:
     branches: [ "master" ]
+
 # Declare default permissions as read only.
 permissions: read-all
+
 jobs:
   analysis:
     name: Scorecard analysis
@@ -25,25 +28,39 @@ jobs:
       security-events: write
       # Needed to publish results and get a badge (see publish_results below).
       id-token: write
-      # Needed to read source code and branch protection settings.
-      contents: read
-      actions: read
+      # Uncomment the permissions below if installing in a private repository.
+      # contents: read
+      # actions: read
+
     steps:
       - name: "Checkout code"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
+
       - name: "Run analysis"
         uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
         with:
           results_file: results.sarif
           results_format: sarif
-          # PAT token with Administration (read) permission for Branch-Protection check.
-          # Create a fine-grained PAT following:
-          # https://github.com/ossf/scorecard-action?tab=readme-ov-file#authentication-with-fine-grained-pat-optional
-          # Then add it as a repository secret named SCORECARD_TOKEN.
-          repo_token: ${{ secrets.SCORECARD_TOKEN }}
+          # (Optional) "write" PAT token. Uncomment the `repo_token` line below if:
+          # - you want to enable the Branch-Protection check on a *public* repository, or
+          # - you are installing Scorecard on a *private* repository
+          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action?tab=readme-ov-file#authentication-with-fine-grained-pat-optional.
+          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
+
+          # Public repositories:
+          #   - Publish results to OpenSSF REST API for easy access by consumers
+          #   - Allows the repository to include the Scorecard badge.
+          #   - See https://github.com/ossf/scorecard-action#publishing-results.
+          # For private repositories:
+          #   - `publish_results` will always be set to `false`, regardless
+          #     of the value entered here.
           publish_results: true
+
+          # (Optional) Uncomment file_mode if you have a .gitattributes with files marked export-ignore
+          # file_mode: git
+
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
@@ -52,6 +69,7 @@ jobs:
           name: SARIF file
           path: results.sarif
           retention-days: 5
+
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"


### PR DESCRIPTION
## What changed
This PR reverts merged PR #1292 (`chore: add PAT to read branch protection rules`).

## Why
PR #1292 added `repo_token: ${{ secrets.SCORECARD_TOKEN }}` to the Scorecard workflow and updated the workflow comments and permissions around that PAT usage. This revert removes that PAT-based configuration and restores the previous workflow contents.

## Impact
- Removes the `SCORECARD_TOKEN` dependency from `.github/workflows/scorecard.yml`
- Restores the prior Scorecard workflow configuration before PR #1292

## Validation
- Reverted merge commit `791645a634d82c6cbe7ab965dd48572701076b8b`
- Parsed `.github/workflows/scorecard.yml` successfully with Ruby YAML

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to make authentication and permission requirements optional
  * Added setup guidance tailored for different repository deployment scenarios
  * Improved workflow documentation with conditional configuration instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->