### PR TITLE
Fixed central instance schema name and topics resolution

### DIFF
--- a/core-services/libraries/services-common/src/main/java/org/egov/common/error/ErrorCode.java
+++ b/core-services/libraries/services-common/src/main/java/org/egov/common/error/ErrorCode.java
@@ -14,4 +14,8 @@ public class ErrorCode {
     public static final String CREATED_TIME_NULL_ERROR_MESSAGE = "CreatedTime present inside AuditDetails being sent to enrichAuditDetails method must not be null in case of update request";
 
     public static final String CREATED_BY_NULL_ERROR_MESSAGE = "CreatedBy present inside AuditDetails being sent to enrichAuditDetails method must not be null in case of update request";
+
+    public static final String INVALID_TENANT_ID_FORMAT = "TenantId contains illegal characters. Each dot-separated segment must be a valid identifier: start with a letter or underscore, followed by letters, digits, or underscores, max 63 chars per segment.";
+
+    public static final String INVALID_SCHEMA_NAME = "Resolved schema name '%s' is not a valid identifier. Must start with a letter or underscore, contain only letters, digits, or underscores, and be at most 63 characters.";
 }

--- a/core-services/libraries/services-common/src/main/java/org/egov/common/exception/InvalidTenantIdFormatException.java
+++ b/core-services/libraries/services-common/src/main/java/org/egov/common/exception/InvalidTenantIdFormatException.java
@@ -1,0 +1,10 @@
+package org.egov.common.exception;
+
+public class InvalidTenantIdFormatException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public InvalidTenantIdFormatException(String message) {
+        super(message);
+    }
+}

--- a/core-services/libraries/services-common/src/main/java/org/egov/common/utils/MultiStateInstanceUtil.java
+++ b/core-services/libraries/services-common/src/main/java/org/egov/common/utils/MultiStateInstanceUtil.java
@@ -2,6 +2,8 @@ package org.egov.common.utils;
 
 import java.util.regex.Pattern;
 
+import org.egov.common.error.ErrorCode;
+import org.egov.common.exception.InvalidTenantIdFormatException;
 import org.egov.common.exception.InvalidTenantIdException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
@@ -17,7 +19,9 @@ import lombok.NoArgsConstructor;
 public class MultiStateInstanceUtil {
 
     // central-instance configs
-	public static String SCHEMA_REPLACE_STRING = "{schema}";
+	public static final String SCHEMA_REPLACE_STRING = "{schema}";
+
+    private static final Pattern SCHEMA_NAME_PATTERN = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_]{0,62}$");
     /*
      * Represents the length of the tenantId array when it's split by "."
      *
@@ -40,6 +44,15 @@ public class MultiStateInstanceUtil {
      */
     @Value("${state.schema.index.position.tenantid:1}")
     private Integer stateSchemaIndexPositionInTenantId;
+
+    private void validateTenantId(String tenantId) {
+        if (tenantId == null || tenantId.isEmpty())
+            throw new InvalidTenantIdFormatException(ErrorCode.INVALID_TENANT_ID_FORMAT);
+        for (String segment : tenantId.split("\\.", -1)) {
+            if (!SCHEMA_NAME_PATTERN.matcher(segment).matches())
+                throw new InvalidTenantIdFormatException(ErrorCode.INVALID_TENANT_ID_FORMAT);
+        }
+    }
 
     /**
      * Resolves the schema name from a tenantId using {@code stateSchemaIndexPositionInTenantId}.
@@ -72,7 +85,10 @@ public class MultiStateInstanceUtil {
         String[] parts = tenantId.split("\\.");
         if (parts.length == 1) return tenantId;
         int idx = Math.min(stateSchemaIndexPositionInTenantId, parts.length - 1);
-        return parts[idx];
+        String schema = parts[idx];
+        if (!SCHEMA_NAME_PATTERN.matcher(schema).matches())
+            throw new InvalidTenantIdFormatException(String.format(ErrorCode.INVALID_SCHEMA_NAME, schema));
+        return schema;
     }
 
 	/**
@@ -95,6 +111,7 @@ public class MultiStateInstanceUtil {
 	 * </pre>
 	 */
 	public String replaceSchemaPlaceholder(String query, String tenantId) throws InvalidTenantIdException {
+		validateTenantId(tenantId);
 		if (getIsEnvironmentCentralInstance()) {
 			String schemaName = resolveSchemaName(tenantId);
 			return query.replaceAll("(?i)" + Pattern.quote(SCHEMA_REPLACE_STRING), schemaName);
@@ -220,7 +237,7 @@ public class MultiStateInstanceUtil {
 	 * @return
 	 */
 	public String getStateSpecificTopicName(String tenantId, String topic) {
-
+		validateTenantId(tenantId);
 		if (getIsEnvironmentCentralInstance()) {
 			String schema = resolveSchemaName(tenantId);
 			return schema.concat("-").concat(topic);

--- a/core-services/libraries/services-common/src/main/java/org/egov/common/utils/MultiStateInstanceUtil.java
+++ b/core-services/libraries/services-common/src/main/java/org/egov/common/utils/MultiStateInstanceUtil.java
@@ -20,9 +20,9 @@ public class MultiStateInstanceUtil {
 	public static String SCHEMA_REPLACE_STRING = "{schema}";
     /*
      * Represents the length of the tenantId array when it's split by "."
-     * 
-     * if the array length is equal or lesser than, then the tennatId belong to state level
-     * 
+     *
+     * if the array length is equal or lesser than, then the tenantId belong to state level
+     *
      * else it's tenant level
      */
     @Value("${state.level.tenantid.length:1}")
@@ -40,35 +40,88 @@ public class MultiStateInstanceUtil {
      */
     @Value("${state.schema.index.position.tenantid:1}")
     private Integer stateSchemaIndexPositionInTenantId;
-    
+
+    /**
+     * Resolves the schema name from a tenantId using {@code stateSchemaIndexPositionInTenantId}.
+     *
+     * <p>If the tenantId has no dots (single part), the tenantId itself is returned regardless
+     * of the configured position. Otherwise the part at {@code min(position, parts.length-1)}
+     * is returned, so the index is always in bounds.
+     *
+     * <pre>
+     * stateSchemaIndexPositionInTenantId = 0:
+     *   "pb"                    -&gt; "pb"   (single part, no dot)
+     *   "pb.amritsar"           -&gt; "pb"   (min(0,1)=0)
+     *   "pb.amritsar.local1"    -&gt; "pb"   (min(0,2)=0)
+     *   "in.pb.amritsar.local1" -&gt; "in"   (min(0,3)=0)
+     *
+     * stateSchemaIndexPositionInTenantId = 1:
+     *   "pb"                    -&gt; "pb"       (single part)
+     *   "pb.amritsar"           -&gt; "amritsar" (min(1,1)=1)
+     *   "pb.amritsar.local1"    -&gt; "amritsar" (min(1,2)=1)
+     *   "pb.amritsar.local1.v"  -&gt; "amritsar" (min(1,3)=1)
+     *
+     * stateSchemaIndexPositionInTenantId = 2:
+     *   "pb"                        -&gt; "pb"       (single part)
+     *   "pb.amritsar"               -&gt; "amritsar" (min(2,1)=1, capped)
+     *   "pb.amritsar.local1"        -&gt; "local1"   (min(2,2)=2)
+     *   "pb.amritsar.local1.mohali" -&gt; "local1"   (min(2,3)=2, capped)
+     * </pre>
+     */
+    private String resolveSchemaName(String tenantId) {
+        String[] parts = tenantId.split("\\.");
+        if (parts.length == 1) return tenantId;
+        int idx = Math.min(stateSchemaIndexPositionInTenantId, parts.length - 1);
+        return parts[idx];
+    }
+
 	/**
-	 * Method to fetch the state name from the tenantId
-	 * 
-	 * @param query
-	 * @param tenantId
-	 * @return
+	 * Replaces the {@code {schema}} placeholder in a query with the schema name derived
+	 * from the tenantId.
+	 *
+	 * <p>When central instance is enabled the schema is resolved via
+	 * {@link #resolveSchemaName(String)} (see that method for the full truth table).
+	 * When disabled, {@code {schema}.} is stripped so queries work against the default schema.
+	 *
+	 * <pre>
+	 * central=true, position=1, query="select * from {schema}.employee":
+	 *   "pb"                 -&gt; "select * from pb.employee"
+	 *   "pb.amritsar"        -&gt; "select * from amritsar.employee"
+	 *   "pb.amritsar.local1" -&gt; "select * from amritsar.employee"
+	 *
+	 * central=false (any tenantId):
+	 *   "pb"                 -&gt; "select * from employee"
+	 *   "pb.amritsar"        -&gt; "select * from employee"
+	 * </pre>
 	 */
 	public String replaceSchemaPlaceholder(String query, String tenantId) throws InvalidTenantIdException {
-
-		String finalQuery = null;
-		if (tenantId.contains(".") && getIsEnvironmentCentralInstance()) {
-
-			if (stateSchemaIndexPositionInTenantId >= tenantId.length()) {
-				throw new InvalidTenantIdException(
-						"The tenantId length is smaller than the defined schema index in tenantId for central instance");
-			}
-			String schemaName = tenantId.split("\\.")[getStateSchemaIndexPositionInTenantId()];
-			finalQuery = query.replaceAll("(?i)" + Pattern.quote(SCHEMA_REPLACE_STRING), schemaName);
-		} else {
-			finalQuery = query.replaceAll("(?i)" + Pattern.quote(SCHEMA_REPLACE_STRING.concat(".")), "");
+		if (getIsEnvironmentCentralInstance()) {
+			String schemaName = resolveSchemaName(tenantId);
+			return query.replaceAll("(?i)" + Pattern.quote(SCHEMA_REPLACE_STRING), schemaName);
 		}
-		return finalQuery;
+		return query.replaceAll("(?i)" + Pattern.quote(SCHEMA_REPLACE_STRING.concat(".")), "");
 	}
-	
+
 	/**
-	 * Method to determine if the given tenantId belong to tenant or state level in
-	 * the current environment
-	 * 
+	 * Method to determine if the given tenantId belongs to tenant or state level in
+	 * the current environment.
+	 *
+	 * <pre>
+	 * central=true, stateLevelTenantIdLength=1:
+	 *   "pb"                 -&gt; true  (1 part  &lt;= 1)
+	 *   "pb.amritsar"        -&gt; false (2 parts &gt; 1)
+	 *   "pb.amritsar.local1" -&gt; false (3 parts &gt; 1)
+	 *
+	 * central=true, stateLevelTenantIdLength=2:
+	 *   "pb"                 -&gt; true  (1 part  &lt;= 2)
+	 *   "pb.amritsar"        -&gt; true  (2 parts &lt;= 2)
+	 *   "pb.amritsar.local1" -&gt; false (3 parts &gt; 2)
+	 *
+	 * central=false (dot check only):
+	 *   "pb"                 -&gt; true  (no dot)
+	 *   "pb.amritsar"        -&gt; false (has dot)
+	 * </pre>
+	 *
 	 * @param tenantId
 	 * @return
 	 */
@@ -90,13 +143,36 @@ public class MultiStateInstanceUtil {
 	}
 	
 	/**
-	 * For central instance if the tenantId size is lesser than state level
-	 * length the same will be returned without splitting
-	 * 
-	 * if the tenant-id is longer than the given stateTenantlength then the length of tenant-id
-	 * till state-level index will be returned 
-	 * (for example if statetenantlength is 1 and tenant-id is 'in.statea.tenantx'. the returned tenant-id will be in.statea)
-	 * 
+	 * For central instance: if the tenantId has fewer parts than {@code stateLevelTenantIdLength}
+	 * the same tenantId is returned. Otherwise the tenantId is trimmed to the first
+	 * {@code stateLevelTenantIdLength} dot-separated parts.
+	 *
+	 * <p>For non-central instance: always returns the first part of the tenantId (split by dot).
+	 *
+	 * <pre>
+	 * central=true, stateLevelTenantIdLength=1:
+	 *   "pb"                 -&gt; "pb"
+	 *   "pb.amritsar"        -&gt; "pb"
+	 *   "pb.amritsar.local1" -&gt; "pb"
+	 *
+	 * central=true, stateLevelTenantIdLength=2:
+	 *   "pb"                     -&gt; "pb"
+	 *   "pb.amritsar"            -&gt; "pb.amritsar"
+	 *   "pb.amritsar.local1"     -&gt; "pb.amritsar"
+	 *   "pb.amritsar.local1.m"   -&gt; "pb.amritsar"
+	 *
+	 * central=true, stateLevelTenantIdLength=3:
+	 *   "pb"                         -&gt; "pb"
+	 *   "pb.amritsar"                -&gt; "pb.amritsar"
+	 *   "pb.amritsar.local1"         -&gt; "pb.amritsar.local1"
+	 *   "pb.amritsar.local1.mohali"  -&gt; "pb.amritsar.local1"
+	 *
+	 * central=false (any stateLevelTenantIdLength):
+	 *   "pb"                 -&gt; "pb"
+	 *   "pb.amritsar"        -&gt; "pb"
+	 *   "pb.amritsar.local1" -&gt; "pb"
+	 * </pre>
+	 *
 	 * @param tenantId
 	 * @return
 	 */
@@ -115,23 +191,40 @@ public class MultiStateInstanceUtil {
 		}
 		return stateTenant;
 	}
-	
+
 	/**
-	 * method to prefix the state specific tag to the topic names
-	 * 
+	 * Returns a state-specific Kafka topic name by prepending the schema prefix.
+	 *
+	 * <p>When central instance is enabled the schema is resolved via
+	 * {@link #resolveSchemaName(String)} and prepended as {@code schema-topic}.
+	 * When disabled, the topic is returned unchanged.
+	 *
+	 * <pre>
+	 * central=true, position=1, topic="save-employee":
+	 *   "pb"                 -&gt; "pb-save-employee"
+	 *   "pb.amritsar"        -&gt; "amritsar-save-employee"
+	 *   "pb.amritsar.local1" -&gt; "amritsar-save-employee"
+	 *
+	 * central=true, position=0, topic="save-employee":
+	 *   "pb"             -&gt; "pb-save-employee"
+	 *   "pb.amritsar"    -&gt; "pb-save-employee"
+	 *   "in.pb.amritsar" -&gt; "in-save-employee"
+	 *
+	 * central=false (any tenantId):
+	 *   "pb"             -&gt; "save-employee"
+	 *   "pb.amritsar"    -&gt; "save-employee"
+	 * </pre>
+	 *
 	 * @param tenantId
 	 * @param topic
 	 * @return
 	 */
 	public String getStateSpecificTopicName(String tenantId, String topic) {
-		
-		String updatedTopic = topic;
-		if (getIsEnvironmentCentralInstance()) {
 
-			String[] tenants = tenantId.split("\\.");
-			if (tenants.length > 1)
-				updatedTopic = tenants[stateSchemaIndexPositionInTenantId].concat("-").concat(topic);
+		if (getIsEnvironmentCentralInstance()) {
+			String schema = resolveSchemaName(tenantId);
+			return schema.concat("-").concat(topic);
 		}
-		return updatedTopic;
+		return topic;
 	}
 }

--- a/core-services/libraries/services-common/src/test/java/org/egov/common/utils/MultiStateInstanceUtilTest.java
+++ b/core-services/libraries/services-common/src/test/java/org/egov/common/utils/MultiStateInstanceUtilTest.java
@@ -1,7 +1,10 @@
 package org.egov.common.utils;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+import org.egov.common.exception.InvalidTenantIdException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -9,38 +12,312 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class MultiStateInstanceUtilTest {
 
-	@Test
-	public void testIfStateLevelTenantIdIsReturnedForCentralDeployment(){
-	
-		MultiStateInstanceUtil centralUtil = new MultiStateInstanceUtil(2, true, 1);
-		String InputTenantId = "in.statea.tenantx";
-		String outputTenant = "in.statea";
-		String actualOutputTenantId = centralUtil.getStateLevelTenant(InputTenantId);
-		
-		assertEquals(actualOutputTenantId, outputTenant);
-	}
-	
-	@Test
-	public void testIfSameTenantIdIsReturnedIfStateLengthIslargerThanActualTenantLength(){
-	
-		MultiStateInstanceUtil centralUtil = new MultiStateInstanceUtil(3, true, 1);
-		String InputTenantId = "in.statea.tenantx";
-		String outputTenant = "in.statea.tenantx";
-		String actualOutputTenantId = centralUtil.getStateLevelTenant(InputTenantId);
-		
-		assertEquals(actualOutputTenantId, outputTenant);
-	}
-	
-	@Test
-	public void testIfStateLevelTenantIdIsReturnedForIsolatedDeployment(){
-	
-		MultiStateInstanceUtil centralUtil = new MultiStateInstanceUtil(2, false, 1);
-		String InputTenantId = "in.statea.tenantx";
-		String outputTenant = "in";
-		
-		String actualOutputTenantId = centralUtil.getStateLevelTenant(InputTenantId);
-		
-		assertEquals(actualOutputTenantId, outputTenant);
-	}
+    // -------------------------------------------------------------------------
+    // Existing: getStateLevelTenant
+    // -------------------------------------------------------------------------
 
+    @Test
+    public void testIfStateLevelTenantIdIsReturnedForCentralDeployment() {
+
+        MultiStateInstanceUtil centralUtil = new MultiStateInstanceUtil(2, true, 1);
+        String InputTenantId = "in.statea.tenantx";
+        String outputTenant = "in.statea";
+        String actualOutputTenantId = centralUtil.getStateLevelTenant(InputTenantId);
+
+        assertEquals(actualOutputTenantId, outputTenant);
+    }
+
+    @Test
+    public void testIfSameTenantIdIsReturnedIfStateLengthIslargerThanActualTenantLength() {
+
+        MultiStateInstanceUtil centralUtil = new MultiStateInstanceUtil(3, true, 1);
+        String InputTenantId = "in.statea.tenantx";
+        String outputTenant = "in.statea.tenantx";
+        String actualOutputTenantId = centralUtil.getStateLevelTenant(InputTenantId);
+
+        assertEquals(actualOutputTenantId, outputTenant);
+    }
+
+    @Test
+    public void testIfStateLevelTenantIdIsReturnedForIsolatedDeployment() {
+
+        MultiStateInstanceUtil centralUtil = new MultiStateInstanceUtil(2, false, 1);
+        String InputTenantId = "in.statea.tenantx";
+        String outputTenant = "in";
+
+        String actualOutputTenantId = centralUtil.getStateLevelTenant(InputTenantId);
+
+        assertEquals(actualOutputTenantId, outputTenant);
+    }
+
+    // -------------------------------------------------------------------------
+    // getStateLevelTenant — truth table coverage (India/Punjab examples)
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testGetStateLevelTenant_central_length1_singlePart() {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(1, true, 1);
+        assertEquals("pb", util.getStateLevelTenant("pb"));
+    }
+
+    @Test
+    public void testGetStateLevelTenant_central_length1_twoParts() {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(1, true, 1);
+        assertEquals("pb", util.getStateLevelTenant("pb.amritsar"));
+    }
+
+    @Test
+    public void testGetStateLevelTenant_central_length1_threeParts() {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(1, true, 1);
+        assertEquals("pb", util.getStateLevelTenant("pb.amritsar.local1"));
+    }
+
+    @Test
+    public void testGetStateLevelTenant_central_length2_singlePart() {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(2, true, 1);
+        assertEquals("pb", util.getStateLevelTenant("pb"));
+    }
+
+    @Test
+    public void testGetStateLevelTenant_central_length2_twoParts() {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(2, true, 1);
+        assertEquals("pb.amritsar", util.getStateLevelTenant("pb.amritsar"));
+    }
+
+    @Test
+    public void testGetStateLevelTenant_central_length2_threeParts() {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(2, true, 1);
+        assertEquals("pb.amritsar", util.getStateLevelTenant("pb.amritsar.local1"));
+    }
+
+    @Test
+    public void testGetStateLevelTenant_central_length2_fourParts() {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(2, true, 1);
+        assertEquals("pb.amritsar", util.getStateLevelTenant("pb.amritsar.local1.mohali"));
+    }
+
+    @Test
+    public void testGetStateLevelTenant_central_length3_threeParts() {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(3, true, 1);
+        assertEquals("pb.amritsar.local1", util.getStateLevelTenant("pb.amritsar.local1"));
+    }
+
+    @Test
+    public void testGetStateLevelTenant_central_length3_fourParts() {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(3, true, 1);
+        assertEquals("pb.amritsar.local1", util.getStateLevelTenant("pb.amritsar.local1.mohali"));
+    }
+
+    @Test
+    public void testGetStateLevelTenant_nonCentral_returnsFirstPart() {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(2, false, 1);
+        assertEquals("pb", util.getStateLevelTenant("pb.amritsar.local1"));
+    }
+
+    @Test
+    public void testGetStateLevelTenant_nonCentral_singlePart() {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(1, false, 1);
+        assertEquals("pb", util.getStateLevelTenant("pb"));
+    }
+
+    // -------------------------------------------------------------------------
+    // isTenantIdStateLevel
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testIsTenantIdStateLevel_central_length1_singlePart_isState() {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(1, true, 1);
+        assertTrue(util.isTenantIdStateLevel("pb"));
+    }
+
+    @Test
+    public void testIsTenantIdStateLevel_central_length1_twoParts_isNotState() {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(1, true, 1);
+        assertFalse(util.isTenantIdStateLevel("pb.amritsar"));
+    }
+
+    @Test
+    public void testIsTenantIdStateLevel_central_length1_threeParts_isNotState() {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(1, true, 1);
+        assertFalse(util.isTenantIdStateLevel("pb.amritsar.local1"));
+    }
+
+    @Test
+    public void testIsTenantIdStateLevel_central_length2_singlePart_isState() {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(2, true, 1);
+        assertTrue(util.isTenantIdStateLevel("pb"));
+    }
+
+    @Test
+    public void testIsTenantIdStateLevel_central_length2_twoParts_isState() {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(2, true, 1);
+        assertTrue(util.isTenantIdStateLevel("pb.amritsar"));
+    }
+
+    @Test
+    public void testIsTenantIdStateLevel_central_length2_threeParts_isNotState() {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(2, true, 1);
+        assertFalse(util.isTenantIdStateLevel("pb.amritsar.local1"));
+    }
+
+    @Test
+    public void testIsTenantIdStateLevel_nonCentral_noDot_isState() {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(1, false, 1);
+        assertTrue(util.isTenantIdStateLevel("pb"));
+    }
+
+    @Test
+    public void testIsTenantIdStateLevel_nonCentral_hasDot_isNotState() {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(1, false, 1);
+        assertFalse(util.isTenantIdStateLevel("pb.amritsar"));
+    }
+
+    // -------------------------------------------------------------------------
+    // replaceSchemaPlaceholder — central=true
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testReplaceSchemaPlaceholder_central_position1_singlePartTenant() throws InvalidTenantIdException {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(1, true, 1);
+        String result = util.replaceSchemaPlaceholder("select * from {schema}.employee", "pb");
+        assertEquals("select * from pb.employee", result);
+    }
+
+    @Test
+    public void testReplaceSchemaPlaceholder_central_position1_twoParts() throws InvalidTenantIdException {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(1, true, 1);
+        String result = util.replaceSchemaPlaceholder("select * from {schema}.employee", "pb.amritsar");
+        assertEquals("select * from amritsar.employee", result);
+    }
+
+    @Test
+    public void testReplaceSchemaPlaceholder_central_position1_threeParts() throws InvalidTenantIdException {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(1, true, 1);
+        String result = util.replaceSchemaPlaceholder("select * from {schema}.employee", "pb.amritsar.local1");
+        assertEquals("select * from amritsar.employee", result);
+    }
+
+    @Test
+    public void testReplaceSchemaPlaceholder_central_position0_twoParts() throws InvalidTenantIdException {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(1, true, 0);
+        String result = util.replaceSchemaPlaceholder("select * from {schema}.employee", "pb.amritsar");
+        assertEquals("select * from pb.employee", result);
+    }
+
+    @Test
+    public void testReplaceSchemaPlaceholder_central_position0_fourParts() throws InvalidTenantIdException {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(1, true, 0);
+        String result = util.replaceSchemaPlaceholder("select * from {schema}.employee", "in.pb.amritsar.local1");
+        assertEquals("select * from in.employee", result);
+    }
+
+    @Test
+    public void testReplaceSchemaPlaceholder_central_position2_twoPartsCapped() throws InvalidTenantIdException {
+        // position=2 but only 2 parts -> capped to index 1
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(1, true, 2);
+        String result = util.replaceSchemaPlaceholder("select * from {schema}.employee", "pb.amritsar");
+        assertEquals("select * from amritsar.employee", result);
+    }
+
+    @Test
+    public void testReplaceSchemaPlaceholder_central_position2_threeParts() throws InvalidTenantIdException {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(1, true, 2);
+        String result = util.replaceSchemaPlaceholder("select * from {schema}.employee", "pb.amritsar.local1");
+        assertEquals("select * from local1.employee", result);
+    }
+
+    @Test
+    public void testReplaceSchemaPlaceholder_central_position2_fourPartsCapped() throws InvalidTenantIdException {
+        // position=2, 4 parts -> capped to index 2 (not 3)
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(1, true, 2);
+        String result = util.replaceSchemaPlaceholder("select * from {schema}.employee", "pb.amritsar.local1.mohali");
+        assertEquals("select * from local1.employee", result);
+    }
+
+    // -------------------------------------------------------------------------
+    // replaceSchemaPlaceholder — central=false
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testReplaceSchemaPlaceholder_nonCentral_stripsSchemaPrefix() throws InvalidTenantIdException {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(1, false, 1);
+        String result = util.replaceSchemaPlaceholder("select * from {schema}.employee", "pb");
+        assertEquals("select * from employee", result);
+    }
+
+    @Test
+    public void testReplaceSchemaPlaceholder_nonCentral_multiPartTenant_stripsSchemaPrefix() throws InvalidTenantIdException {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(1, false, 1);
+        String result = util.replaceSchemaPlaceholder("select * from {schema}.employee", "pb.amritsar");
+        assertEquals("select * from employee", result);
+    }
+
+    // -------------------------------------------------------------------------
+    // getStateSpecificTopicName — central=true
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testGetStateSpecificTopicName_central_position1_singlePart() {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(1, true, 1);
+        assertEquals("pb-save-employee", util.getStateSpecificTopicName("pb", "save-employee"));
+    }
+
+    @Test
+    public void testGetStateSpecificTopicName_central_position1_twoParts() {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(1, true, 1);
+        assertEquals("amritsar-save-employee", util.getStateSpecificTopicName("pb.amritsar", "save-employee"));
+    }
+
+    @Test
+    public void testGetStateSpecificTopicName_central_position1_threeParts() {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(1, true, 1);
+        assertEquals("amritsar-save-employee", util.getStateSpecificTopicName("pb.amritsar.local1", "save-employee"));
+    }
+
+    @Test
+    public void testGetStateSpecificTopicName_central_position0_twoParts() {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(1, true, 0);
+        assertEquals("pb-save-employee", util.getStateSpecificTopicName("pb.amritsar", "save-employee"));
+    }
+
+    @Test
+    public void testGetStateSpecificTopicName_central_position0_fourParts() {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(1, true, 0);
+        assertEquals("in-save-employee", util.getStateSpecificTopicName("in.pb.amritsar", "save-employee"));
+    }
+
+    @Test
+    public void testGetStateSpecificTopicName_central_position2_twoPartsCapped() {
+        // position=2, only 2 parts -> capped to index 1
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(1, true, 2);
+        assertEquals("amritsar-save-employee", util.getStateSpecificTopicName("pb.amritsar", "save-employee"));
+    }
+
+    @Test
+    public void testGetStateSpecificTopicName_central_position2_threeParts() {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(1, true, 2);
+        assertEquals("local1-save-employee", util.getStateSpecificTopicName("pb.amritsar.local1", "save-employee"));
+    }
+
+    @Test
+    public void testGetStateSpecificTopicName_central_position2_fourPartsCapped() {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(1, true, 2);
+        assertEquals("local1-save-employee", util.getStateSpecificTopicName("pb.amritsar.local1.mohali", "save-employee"));
+    }
+
+    // -------------------------------------------------------------------------
+    // getStateSpecificTopicName — central=false
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testGetStateSpecificTopicName_nonCentral_topicUnchanged() {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(1, false, 1);
+        assertEquals("save-employee", util.getStateSpecificTopicName("pb", "save-employee"));
+    }
+
+    @Test
+    public void testGetStateSpecificTopicName_nonCentral_multiPartTenant_topicUnchanged() {
+        MultiStateInstanceUtil util = new MultiStateInstanceUtil(1, false, 1);
+        assertEquals("save-employee", util.getStateSpecificTopicName("pb.amritsar", "save-employee"));
+    }
 }


### PR DESCRIPTION
# MultiStateInstanceUtil ? Use Cases & Truth Tables

## Overview

`MultiStateInstanceUtil` provides tenant-aware routing for **central instance** (multi-state) deployments where multiple states share a single server. It solves three problems:

| Problem | Method |
|---------|--------|
| Route SQL queries to the correct per-state DB schema | `replaceSchemaPlaceholder` |
| Route Kafka messages to the correct per-state topic | `getStateSpecificTopicName` |
| Determine the state-level tenant from a deep tenant ID | `getStateLevelTenant` |
| Check whether a tenant ID is at state level | `isTenantIdStateLevel` |

---

## Configuration Properties

| Property | Default | Purpose |
|----------|---------|---------|
| `is.environment.central.instance` | `false` | Enables central instance mode |
| `state.schema.index.position.tenantid` | `1` | Which dot-separated segment of the tenant ID identifies the DB schema / Kafka prefix |
| `state.level.tenantid.length` | `1` | How many dot-separated segments constitute a state-level tenant ID |

---

## Tenant ID Structure (India / Punjab Examples)

Tenant IDs are dot-separated hierarchies. Common structures:

```
pb                        # state only (1 part)
pb.amritsar               # state + city (2 parts)
pb.amritsar.local1        # state + city + local body (3 parts)
pb.amritsar.local1.mohali # state + city + local body + village (4 parts)
in.pb.amritsar            # country + state + city (3 parts, country-rooted)
```

---

## Schema / Topic Prefix Resolution (`resolveSchemaName`)

This is the shared core algorithm used by both `replaceSchemaPlaceholder` and `getStateSpecificTopicName`.

**Rule:**
- If the tenant ID has **no dots** (single segment) ? return the tenant ID as-is.
- Otherwise ? return `split[ min(position, parts.length ? 1) ]`

The `min` prevents `ArrayIndexOutOfBoundsException` when the configured position exceeds the actual depth of the tenant ID; in that case the deepest available segment is used.

### position = 0 (root/country as schema)

| Tenant ID | Parts | Effective Index | Schema |
|-----------|-------|-----------------|--------|
| `pb` | `["pb"]` | ? (single part) | `pb` |
| `pb.amritsar` | `["pb", "amritsar"]` | min(0, 1) = **0** | `pb` |
| `pb.amritsar.local1` | `["pb", "amritsar", "local1"]` | min(0, 2) = **0** | `pb` |
| `in.pb.amritsar.local1` | `["in", "pb", "amritsar", "local1"]` | min(0, 3) = **0** | `in` |

### position = 1 (state as schema ? typical Punjab setup)

| Tenant ID | Parts | Effective Index | Schema |
|-----------|-------|-----------------|--------|
| `pb` | `["pb"]` | ? (single part) | `pb` |
| `pb.amritsar` | `["pb", "amritsar"]` | min(1, 1) = **1** | `amritsar` |
| `pb.amritsar.local1` | `["pb", "amritsar", "local1"]` | min(1, 2) = **1** | `amritsar` |
| `pb.amritsar.local1.v` | `["pb", "amritsar", "local1", "v"]` | min(1, 3) = **1** | `amritsar` |

### position = 2 (city as schema)

| Tenant ID | Parts | Effective Index | Schema |
|-----------|-------|-----------------|--------|
| `pb` | `["pb"]` | ? (single part) | `pb` |
| `pb.amritsar` | `["pb", "amritsar"]` | min(2, 1) = **1** *(capped)* | `amritsar` |
| `pb.amritsar.local1` | `["pb", "amritsar", "local1"]` | min(2, 2) = **2** | `local1` |
| `pb.amritsar.local1.mohali` | `["pb", "amritsar", "local1", "mohali"]` | min(2, 3) = **2** *(capped)* | `local1` |

---

## `replaceSchemaPlaceholder(query, tenantId)`

Replaces the `{schema}` token in a SQL query string with the resolved schema name.

**Central instance disabled:** strips `{schema}.` entirely so the query runs against the service's default schema.

### Central instance enabled ? position = 1

Query template: `"select * from {schema}.employee"`

| Tenant ID | Schema | Result |
|-----------|--------|--------|
| `pb` | `pb` | `select * from pb.employee` |
| `pb.amritsar` | `amritsar` | `select * from amritsar.employee` |
| `pb.amritsar.local1` | `amritsar` | `select * from amritsar.employee` |
| `pb.amritsar.local1.mohali` | `amritsar` | `select * from amritsar.employee` |

### Central instance disabled (any tenant ID)

| Tenant ID | Result |
|-----------|--------|
| `pb` | `select * from employee` |
| `pb.amritsar` | `select * from employee` |
| `pb.amritsar.local1` | `select * from employee` |

> **Note:** When disabled, `{schema}.` (including the trailing dot) is stripped so there is no dangling separator in the query.

---

## `getStateSpecificTopicName(tenantId, topic)`

Prepends the resolved schema name to the Kafka topic so each state writes to its own topic namespace.

**Central instance disabled:** topic is returned unchanged.

### Central instance enabled ? position = 1, topic = `"save-employee"`

| Tenant ID | Schema | Topic |
|-----------|--------|-------|
| `pb` | `pb` | `pb-save-employee` |
| `pb.amritsar` | `amritsar` | `amritsar-save-employee` |
| `pb.amritsar.local1` | `amritsar` | `amritsar-save-employee` |
| `pb.amritsar.local1.mohali` | `amritsar` | `amritsar-save-employee` |

### Central instance enabled ? position = 0, topic = `"save-employee"`

| Tenant ID | Schema | Topic |
|-----------|--------|-------|
| `pb` | `pb` | `pb-save-employee` |
| `pb.amritsar` | `pb` | `pb-save-employee` |
| `in.pb.amritsar` | `in` | `in-save-employee` |

### Central instance enabled ? position = 2, topic = `"save-employee"`

| Tenant ID | Schema | Topic |
|-----------|--------|-------|
| `pb` | `pb` | `pb-save-employee` |
| `pb.amritsar` | `amritsar` *(capped from pos 2)* | `amritsar-save-employee` |
| `pb.amritsar.local1` | `local1` | `local1-save-employee` |
| `pb.amritsar.local1.mohali` | `local1` *(capped)* | `local1-save-employee` |

### Central instance disabled

| Tenant ID | Topic (unchanged) |
|-----------|-------------------|
| `pb` | `save-employee` |
| `pb.amritsar` | `save-employee` |

---

## `getStateLevelTenant(tenantId)`

Returns the state-level prefix of a tenant ID by trimming it to `stateLevelTenantIdLength` segments.

**Central instance disabled:** always returns the first segment (split by dot).

### Central instance enabled ? `stateLevelTenantIdLength = 1`

| Tenant ID | Condition (`1 < parts`) | Result |
|-----------|-------------------------|--------|
| `pb` | `1 < 1` ? false ? return as-is | `pb` |
| `pb.amritsar` | `1 < 2` ? true, trim to 1 part | `pb` |
| `pb.amritsar.local1` | `1 < 3` ? true, trim to 1 part | `pb` |
| `pb.amritsar.local1.mohali` | `1 < 4` ? true, trim to 1 part | `pb` |

### Central instance enabled ? `stateLevelTenantIdLength = 2`

| Tenant ID | Condition (`2 < parts`) | Result |
|-----------|-------------------------|--------|
| `pb` | `2 < 1` ? false ? return as-is | `pb` |
| `pb.amritsar` | `2 < 2` ? false ? return as-is | `pb.amritsar` |
| `pb.amritsar.local1` | `2 < 3` ? true, trim to 2 parts | `pb.amritsar` |
| `pb.amritsar.local1.mohali` | `2 < 4` ? true, trim to 2 parts | `pb.amritsar` |

### Central instance enabled ? `stateLevelTenantIdLength = 3`

| Tenant ID | Condition (`3 < parts`) | Result |
|-----------|-------------------------|--------|
| `pb` | `3 < 1` ? false ? return as-is | `pb` |
| `pb.amritsar` | `3 < 2` ? false ? return as-is | `pb.amritsar` |
| `pb.amritsar.local1` | `3 < 3` ? false ? return as-is | `pb.amritsar.local1` |
| `pb.amritsar.local1.mohali` | `3 < 4` ? true, trim to 3 parts | `pb.amritsar.local1` |

### Central instance disabled (any `stateLevelTenantIdLength`)

| Tenant ID | Result |
|-----------|--------|
| `pb` | `pb` |
| `pb.amritsar` | `pb` |
| `pb.amritsar.local1` | `pb` |

---

## `isTenantIdStateLevel(tenantId)`

Returns `true` if the tenant ID is at or above the state level.

**Central instance disabled:** uses a simple dot-check ? no dot means state level.

### Central instance enabled ? `stateLevelTenantIdLength = 1`

| Tenant ID | Parts | `parts ? 1` | Result |
|-----------|-------|-------------|--------|
| `pb` | 1 | true | `true` |
| `pb.amritsar` | 2 | false | `false` |
| `pb.amritsar.local1` | 3 | false | `false` |

### Central instance enabled ? `stateLevelTenantIdLength = 2`

| Tenant ID | Parts | `parts ? 2` | Result |
|-----------|-------|-------------|--------|
| `pb` | 1 | true | `true` |
| `pb.amritsar` | 2 | true | `true` |
| `pb.amritsar.local1` | 3 | false | `false` |

### Central instance disabled

| Tenant ID | Has dot | Result |
|-----------|---------|--------|
| `pb` | no | `true` |
| `pb.amritsar` | yes | `false` |
| `pb.amritsar.local1` | yes | `false` |

---

## Bug Fixes in This PR

### 1. `ArrayIndexOutOfBoundsException` in `replaceSchemaPlaceholder`

**Before:** direct array access without bounds check.
```java
// stateSchemaIndexPositionInTenantId=2, tenantId="pb.amritsar" ? split has 2 elements ? CRASH
schemaName = tenantId.split("\\.")[getStateSchemaIndexPositionInTenantId()];
```

**After:** safe capped access via `resolveSchemaName`.
```java
int idx = Math.min(stateSchemaIndexPositionInTenantId, parts.length - 1);
return parts[idx];
```

### 2. `ArrayIndexOutOfBoundsException` in `getStateSpecificTopicName`

Same root cause as above ? direct array access without bounds check.

### 3. Dead code: wrong bounds check

**Before:**
```java
if (stateSchemaIndexPositionInTenantId >= tenantId.length()) {
    // compared against character length, not array length ? always wrong
    // empty block ? no exception, no fallback
}
```

**After:** removed entirely; the `Math.min` guard in `resolveSchemaName` makes it unnecessary.

### 4. Duplication removed

Both `replaceSchemaPlaceholder` and `getStateSpecificTopicName` previously contained separate copies of the schema-resolution logic. Both now delegate to the private `resolveSchemaName` method.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tenant-id schema validation and clearer error messages for invalid tenant formats.
* **Bug Fixes**
  * Fixed schema placeholder replacement and topic-name prefixing for single-part and capped tenant IDs in central mode.
* **Tests**
  * Expanded unit tests covering central/non-central behaviors, multi-part tenant IDs, placeholder replacements, and topic naming.
* **Chores**
  * Made schema-replace constant immutable and introduced a schema-name validation pattern.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/egovernments/Digit-Core/pull/1328)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->