### PR TITLE
feat(egov-enc-service): POST /crypto/v1/_generatekey for new tenants

### DIFF
--- a/core-services/egov-enc-service/pom.xml
+++ b/core-services/egov-enc-service/pom.xml
@@ -16,7 +16,10 @@
     <java.version>17</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <lombok.version>1.18.22</lombok.version>
+    <!-- 1.18.22 throws NoSuchFieldError on JCTree.qualid when compiled
+         with JDK 21+ (Lombok internal API change). 1.18.30+ adds JDK 21
+         support; pinning to 1.18.34 (current stable). -->
+    <lombok.version>1.18.34</lombok.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/core-services/egov-enc-service/src/main/java/org/egov/enc/services/KeyManagementService.java
+++ b/core-services/egov-enc-service/src/main/java/org/egov/enc/services/KeyManagementService.java
@@ -142,6 +142,65 @@ public class KeyManagementService implements ApplicationRunner {
         return new RotateKeyResponse(true);
     }
 
+    /**
+     * Idempotently provision a symmetric + asymmetric key for a single tenantId.
+     *
+     * The default key-generation path (init() + checkIfTenantExists) only fires
+     * for tenants reachable via MDMS search under STATE_LEVEL_TENANT_ID — brand
+     * new state roots (which are not yet under any existing root's
+     * tenant.tenants list) get a "Tenant Id not found" 500 on first encrypt
+     * because no key exists for them.
+     *
+     * Callers that provision new tenants (e.g. MCP tenant_bootstrap) hit this
+     * BEFORE the first encrypt request for the new tenant. Re-issuing for an
+     * existing tenant is a no-op — the existing keyId is returned, no rotation.
+     *
+     * Synchronized to prevent two concurrent generates for the same fresh
+     * tenant from both inserting (the underlying generateKeys does not have
+     * an INSERT ... ON CONFLICT — duplicate rows would violate the keyId PK).
+     */
+    public synchronized org.egov.enc.web.models.GenerateKeyResponse generateKeyForTenant(String tenantId)
+            throws Exception {
+        if (tenantId == null || tenantId.trim().isEmpty()) {
+            throw new CustomException("INVALID_TENANT_ID", "tenantId must be non-empty");
+        }
+        final String normalized = tenantId.trim();
+
+        // Idempotency: if the tenant already has an active key in the store,
+        // return its keyId — do NOT generate a duplicate. This is the no-op
+        // path that lets callers issue this freely without worrying about state.
+        keyStore.refreshKeys();
+        if (keyStore.getTenantIds().contains(normalized)) {
+            org.egov.enc.models.SymmetricKey existing = keyStore.getSymmetricKey(normalized);
+            return org.egov.enc.web.models.GenerateKeyResponse.builder()
+                    .tenantId(normalized)
+                    .created(false)
+                    .keyId(existing != null ? existing.getId() : null)
+                    .build();
+        }
+
+        // Generate the key pair and persist. Reuses the same private path
+        // that init() and rotateAll() use — symmetric + asymmetric inserts
+        // in one shot; failure halfway throws and the caller can retry.
+        ArrayList<String> tenants = new ArrayList<>();
+        tenants.add(normalized);
+        generateKeys(tenants);
+
+        // Refresh in-memory caches so the next encrypt for this tenant
+        // resolves directly without going through the MDMS-discovery fallback.
+        keyStore.refreshKeys();
+        keyIdGenerator.refreshKeyIds();
+
+        org.egov.enc.models.SymmetricKey created = keyStore.getSymmetricKey(normalized);
+        log.info("Generated keys for tenantId={} (keyId={})", normalized,
+                created != null ? created.getId() : "?");
+        return org.egov.enc.web.models.GenerateKeyResponse.builder()
+                .tenantId(normalized)
+                .created(true)
+                .keyId(created != null ? created.getId() : null)
+                .build();
+    }
+
     public RotateKeyResponse rotateKey(RotateKeyRequest rotateKeyRequest) throws Exception {
         int status;
         status = keyRepository.deactivateSymmetricKeyForGivenTenant(rotateKeyRequest.getTenantId());

--- a/core-services/egov-enc-service/src/main/java/org/egov/enc/web/controllers/CryptoApiController.java
+++ b/core-services/egov-enc-service/src/main/java/org/egov/enc/web/controllers/CryptoApiController.java
@@ -70,4 +70,22 @@ public class CryptoApiController{
         return new ResponseEntity<RotateKeyResponse>(keyManagementService.rotateKey(rotateKeyRequest), HttpStatus.OK);
     }
 
+    /**
+     * Provision a symmetric + asymmetric key pair for a tenantId that doesn't
+     * have one yet. Idempotent — returns the existing keyId without rotating
+     * if the tenant already has a key.
+     *
+     * Required for new-state-root provisioning flows (MCP tenant_bootstrap,
+     * etc.) where the default MDMS-driven key discovery doesn't pick up the
+     * new tenant. Without this, the first encrypt for a brand-new tenant
+     * fails with "Tenant Id not found".
+     */
+    @RequestMapping(value = "/crypto/v1/_generatekey", method = RequestMethod.POST)
+    public ResponseEntity<GenerateKeyResponse> cryptoGenerateKey(
+            @Valid @RequestBody GenerateKeyRequest generateKeyRequest) throws Exception {
+        return new ResponseEntity<>(
+                keyManagementService.generateKeyForTenant(generateKeyRequest.getTenantId()),
+                HttpStatus.OK);
+    }
+
 }

--- a/core-services/egov-enc-service/src/main/java/org/egov/enc/web/models/GenerateKeyRequest.java
+++ b/core-services/egov-enc-service/src/main/java/org/egov/enc/web/models/GenerateKeyRequest.java
@@ -1,0 +1,31 @@
+package org.egov.enc.web.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Request body for POST /crypto/v1/_generatekey.
+ *
+ * Generates a symmetric + asymmetric key pair for the given tenantId if one
+ * doesn't already exist. Idempotent — re-issuing for an existing tenant
+ * returns the current keyId without rotating.
+ *
+ * Use case: callers that provision new tenants (e.g. MCP tenant_bootstrap)
+ * need a key to exist BEFORE the first encrypt request for that tenant.
+ * The default key-generation path (init() + checkIfTenantExists) only fires
+ * for tenants reachable via MDMS search under STATE_LEVEL_TENANT_ID, which
+ * excludes brand-new state roots.
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class GenerateKeyRequest {
+
+    @NotNull
+    @JsonProperty("tenantId")
+    private String tenantId;
+}

--- a/core-services/egov-enc-service/src/main/java/org/egov/enc/web/models/GenerateKeyResponse.java
+++ b/core-services/egov-enc-service/src/main/java/org/egov/enc/web/models/GenerateKeyResponse.java
@@ -1,0 +1,29 @@
+package org.egov.enc.web.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+/**
+ * Response from POST /crypto/v1/_generatekey.
+ *   created=true  → a new key was generated and persisted
+ *   created=false → tenant already had a key; this is a no-op
+ *
+ * The `keyId` is always populated on success (whether newly generated or
+ * pre-existing) so callers can correlate downstream encrypt requests.
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class GenerateKeyResponse {
+
+    @JsonProperty("tenantId")
+    private String tenantId;
+
+    @JsonProperty("created")
+    private boolean created;
+
+    @JsonProperty("keyId")
+    private Integer keyId;
+}

--- a/core-services/egov-user/src/main/java/org/egov/user/domain/service/UserService.java
+++ b/core-services/egov-user/src/main/java/org/egov/user/domain/service/UserService.java
@@ -151,7 +151,7 @@ public class UserService {
 
         /* encrypt here */
 
-        userSearchCriteria = encryptionDecryptionUtil.encryptObject(userSearchCriteria, "User", UserSearchCriteria.class);
+        userSearchCriteria = encryptionDecryptionUtil.encryptObject(userSearchCriteria, "User", UserSearchCriteria.class, userSearchCriteria.getTenantId());
         List<User> users = userRepository.findAll(userSearchCriteria);
 
         if (users.isEmpty())
@@ -202,7 +202,7 @@ public class UserService {
         	altmobnumber = searchCriteria.getMobileNumber();
         }
 
-        searchCriteria = encryptionDecryptionUtil.encryptObject(searchCriteria, "User", UserSearchCriteria.class);
+        searchCriteria = encryptionDecryptionUtil.encryptObject(searchCriteria, "User", UserSearchCriteria.class, searchCriteria.getTenantId());
         
         if(altmobnumber!=null) {
         	searchCriteria.setAlternatemobilenumber(altmobnumber);
@@ -229,7 +229,7 @@ public class UserService {
         user.validateNewUser(createUserValidateName);
         conditionallyValidateOtp(user);
         /* encrypt here */
-        user = encryptionDecryptionUtil.encryptObject(user, "User", User.class);
+        user = encryptionDecryptionUtil.encryptObject(user, "User", User.class, user.getTenantId());
         validateUserUniqueness(user);
         if (isEmpty(user.getPassword())) {
             user.setPassword(UUID.randomUUID().toString());
@@ -364,7 +364,7 @@ public class UserService {
         validatePassword(user.getPassword());
         user.setPassword(encryptPwd(user.getPassword()));
         /* encrypt */
-        user = encryptionDecryptionUtil.encryptObject(user, "User", User.class);
+        user = encryptionDecryptionUtil.encryptObject(user, "User", User.class, user.getTenantId());
         userRepository.update(user, existingUser,requestInfo.getUserInfo().getId(), requestInfo.getUserInfo().getUuid() );
 
         // If user is being unlocked via update, reset failed login attempts
@@ -415,7 +415,7 @@ public class UserService {
      */
     public User partialUpdate(User user, RequestInfo requestInfo) {
         /* encrypt here */
-        user = encryptionDecryptionUtil.encryptObject(user, "User", User.class);
+        user = encryptionDecryptionUtil.encryptObject(user, "User", User.class, user.getTenantId());
 
         User existingUser = getUserByUuid(user.getUuid());
         validateProfileUpdateIsDoneByTheSameLoggedInUser(user);
@@ -489,7 +489,7 @@ public class UserService {
         user.updatePassword(encryptPwd(request.getNewPassword()));
         /* encrypt here */
         /* encrypted value is stored in DB*/
-        user = encryptionDecryptionUtil.encryptObject(user, "User", User.class);
+        user = encryptionDecryptionUtil.encryptObject(user, "User", User.class, user.getTenantId());
         userRepository.update(user, user,user.getId() , user.getUuid());
     }
 

--- a/core-services/egov-user/src/main/java/org/egov/user/domain/service/utils/EncryptionDecryptionUtil.java
+++ b/core-services/egov-user/src/main/java/org/egov/user/domain/service/utils/EncryptionDecryptionUtil.java
@@ -8,6 +8,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.egov.common.contract.request.RequestInfo;
 import org.egov.common.contract.request.Role;
 import org.egov.common.contract.request.User;
+import org.egov.common.utils.MultiStateInstanceUtil;
 import org.egov.encryption.EncryptionService;
 import org.egov.encryption.audit.AuditService;
 import org.egov.tracer.model.CustomException;
@@ -32,6 +33,9 @@ public class EncryptionDecryptionUtil {
     @Autowired
     private ObjectMapper objectMapper;
 
+    @Autowired
+    private MultiStateInstanceUtil centralInstanceUtil;
+
     @Value(("${state.level.tenant.id}"))
     private String stateLevelTenantId;
 
@@ -48,6 +52,34 @@ public class EncryptionDecryptionUtil {
                 return null;
             }
             T encryptedObject = encryptionService.encryptJson(objectToEncrypt, key, stateLevelTenantId, classType);
+            if (encryptedObject == null) {
+                throw new CustomException("ENCRYPTION_NULL_ERROR", "Null object found on performing encryption");
+            }
+            return encryptedObject;
+        } catch (IOException | HttpClientErrorException | HttpServerErrorException | ResourceAccessException e) {
+            log.error("Error occurred while encrypting", e);
+            throw new CustomException("ENCRYPTION_ERROR", "Error occurred in encryption process");
+        } catch (Exception e) {
+            log.error("Unknown Error occurred while encrypting", e);
+            throw new CustomException("UNKNOWN_ERROR", "Unknown error occurred in encryption process");
+        }
+    }
+
+    /**
+     * Tenant-aware encryption: derives the state-level tenant dynamically from the
+     * provided tenantId instead of using the hardcoded configuration property.
+     * This enables encryption to work correctly for any state root, not just the
+     * configured default.
+     */
+    public <T> T encryptObject(Object objectToEncrypt, String key, Class<T> classType, String tenantId) {
+        try {
+            if (objectToEncrypt == null) {
+                return null;
+            }
+            String resolvedTenantId = (tenantId != null)
+                    ? centralInstanceUtil.getStateLevelTenant(tenantId)
+                    : stateLevelTenantId;
+            T encryptedObject = encryptionService.encryptJson(objectToEncrypt, key, resolvedTenantId, classType);
             if (encryptedObject == null) {
                 throw new CustomException("ENCRYPTION_NULL_ERROR", "Null object found on performing encryption");
             }

--- a/core-services/egov-user/src/main/java/org/egov/user/domain/service/utils/LocalizationUtil.java
+++ b/core-services/egov-user/src/main/java/org/egov/user/domain/service/utils/LocalizationUtil.java
@@ -3,6 +3,7 @@ package org.egov.user.domain.service.utils;
 import com.jayway.jsonpath.JsonPath;
 import lombok.extern.slf4j.Slf4j;
 import org.egov.common.contract.request.RequestInfo;
+import org.egov.common.utils.MultiStateInstanceUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -33,6 +34,8 @@ public class LocalizationUtil {
     private String defaultLocale;
     @Autowired
     private RestTemplate restTemplate;
+    @Autowired
+    private MultiStateInstanceUtil centralInstanceUtil;
 
     public String getLocalizedMessage(String code, String locale, RequestInfo requestInfo) {
         if(locale == null)
@@ -52,6 +55,29 @@ public class LocalizationUtil {
 
     String getUri(String locale) {
         return localizationServiceHost + localizationServiceSearchPath + "?locale=" + locale + "&tenantId=" + tenantId + "&module=" + module;
+    }
+
+    /**
+     * Tenant-aware localization: derives the state-level tenant dynamically from the
+     * provided tenantId instead of using the hardcoded configuration property.
+     */
+    public String getLocalizedMessage(String code, String locale, RequestInfo requestInfo, String userTenantId) {
+        if(locale == null)
+            locale = defaultLocale;
+        String resolvedTenantId = (userTenantId != null)
+                ? centralInstanceUtil.getStateLevelTenant(userTenantId)
+                : tenantId;
+        String uri = localizationServiceHost + localizationServiceSearchPath + "?locale=" + locale + "&tenantId=" + resolvedTenantId + "&module=" + module;
+        Object responseobj = restTemplate.postForObject(uri, requestInfo, Map.class);
+        Object object = JsonPath.read(responseobj,
+                "$.messages[?(@.code==\"" + code + "\")].message");
+        List<String> messages = (ArrayList<String>) object;
+        if(CollectionUtils.isEmpty(messages)){
+            log.warn("No localization messages returned for locale: " + locale +" . Continuing with english language");
+            messages.add(DEFAULT_EMAIL_UPDATION_MESSAGE);
+        }
+        String message = messages.get(0);
+        return message;
     }
 
 }


### PR DESCRIPTION
## Summary

- Adds an idempotent `POST /crypto/v1/_generatekey` endpoint on `egov-enc-service` to provision a symmetric + asymmetric key pair for a single `tenantId`.
- Bumps `lombok` 1.18.22 → 1.18.34 (1.18.22 throws `NoSuchFieldError` on JCTree.qualid under JDK 21, blocking compile on modern build hosts).

## Why

`egov-enc-service` discovers tenants via MDMS search under `STATE_LEVEL_TENANT_ID` (`KeyManagementService.makeComprehensiveListOfTenantIds()`). Brand-new state roots — created by MCP `tenant_bootstrap` or any provisioning flow — are NOT under any existing root's `tenant.tenants` list, so they are invisible to that discovery path.

Result: the first `_encrypt` request for a new state-root throws

```
org.egov.tracer.model.CustomException: <tenant> : Tenant Id not found
```

which cascades back through `egov-user.encryptObject` as `UNKNOWN_ERROR` and breaks every downstream provisioning step (most visibly: the ADMIN user can't be created for the new tenant). This stacks on top of #1044 — the dynamic-tenant fix correctly routes to the new tenant's own key, but the key doesn't exist yet.

`_generatekey` lets the provisioning caller create the key on demand, before the first encrypt for the new tenant.

## Behavior

- **Path:** `POST /crypto/v1/_generatekey`
- **Body:** `{ "tenantId": "ke.newtenant" }`
- **Response:** `200 { "tenantId": "...", "created": <bool>, "keyId": <int> }`
- **Idempotent:** if the tenant already has an active key, returns `created=false` with the existing `keyId`. No rotation. Safe to call repeatedly.
- **Synchronized:** the underlying `generateKeys()` inserts via the symmetric/asymmetric key id PK — two concurrent first-writes for the same tenant would collide. The new method holds a synchronized lock to prevent that.
- **Cache-refresh:** after generation, `KeyStore.refreshKeys()` + `KeyIdGenerator.refreshKeyIds()` so the next `_encrypt` resolves the key directly, without falling back to MDMS discovery.

## Verified end-to-end on Bomet

Built + deployed to `bomet` (`registry.preview.egov.theflywheel.in/egovio/egov-enc-service:generatekey-endpoint`, linux/amd64). Stacked on top of #1044 (`egov-user:dynamic-tenant-bomet`).

```
_generatekey { genkkbc } → 200 { created: true,  keyId: 31  }   # new key
_generatekey { genkkbc } → 200 { created: false, keyId: 31  }   # idempotent
_generatekey { genkfnr } → 200 { created: true,  keyId: 32  }
tenant_bootstrap { target: genkfnr, source: ke } → admin provisioned: true (was 500 before)
login ADMIN@genkfnr → 200

DB:
  eg_enc_symmetric_keys: 2 fresh rows (genkkbc, genkfnr)
  eg_user.username encrypted under genkfnr's OWN key (393665), NOT ke's (8234)

Regression:
  ADMIN@ke login → 200   # existing ciphertexts still decryptable
  /user/_search → 200
```

## Test plan

- [x] `mvn -B clean package -DskipTests` on JDK 21 (after the lombok bump)
- [x] Idempotency: re-issue for an existing tenant returns existing keyId, `created=false`
- [x] New-root provisioning end-to-end on Bomet: encryption succeeds, ADMIN user lands, login works
- [x] Regression: pre-existing `ke` users decryptable, login unchanged

## Related

- Stacks on #1044 (egov-user dynamic-tenant fix) — without that, this endpoint provisions a key but `egov-user` still ignores it.
- The next step is to have MCP `tenant_bootstrap` call this before its first user-create — keeps callers from needing to hit two endpoints manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New encryption key generation endpoint for secure tenant key provisioning with idempotent behavior (no duplicate keys for existing tenants)
  * Enhanced multi-tenant support with tenant-aware encryption and localization across user management services

* **Dependencies**
  * Updated Lombok to version 1.18.34 for improved compatibility with Java 21+

<!-- end of auto-generated comment: release notes by coderabbit.ai -->