### PR TITLE
egov-malware-detection: add Azure Blob Storage support

### DIFF
--- a/core-services/egov-malware-detection/pom.xml
+++ b/core-services/egov-malware-detection/pom.xml
@@ -21,6 +21,7 @@
         <java.version>17</java.version>
         <lombok.version>1.18.22</lombok.version>
         <minio.version>8.6.0</minio.version>
+        <azure-storage.version>5.0.0</azure-storage.version>
         <log4j2.version>2.17.1</log4j2.version>
         <postgresql.version>42.7.11</postgresql.version>
         <flyway.version>9.22.3</flyway.version>
@@ -87,6 +88,13 @@
             <groupId>io.minio</groupId>
             <artifactId>minio</artifactId>
             <version>${minio.version}</version>
+        </dependency>
+
+        <!-- Azure Blob Storage Client (aligned with egov-filestore) -->
+        <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>azure-storage</artifactId>
+            <version>${azure-storage.version}</version>
         </dependency>
 
         <!-- Database -->

--- a/core-services/egov-malware-detection/src/main/java/org/egov/malware/config/AzureBlobConfig.java
+++ b/core-services/egov-malware-detection/src/main/java/org/egov/malware/config/AzureBlobConfig.java
@@ -1,0 +1,36 @@
+package org.egov.malware.config;
+
+import com.microsoft.azure.storage.CloudStorageAccount;
+import com.microsoft.azure.storage.blob.CloudBlobClient;
+import lombok.extern.slf4j.Slf4j;
+import org.egov.tracer.model.CustomException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@Slf4j
+@ConditionalOnProperty(value = "isAzureStorageEnabled", havingValue = "true")
+public class AzureBlobConfig {
+
+    @Autowired
+    private MalwareDetectionConfig config;
+
+    @Bean
+    public CloudBlobClient cloudBlobClient() {
+        log.info("Initializing Azure Blob Storage client for account: {}", config.getAzureAccountName());
+        String connectionString = String.format(
+                "DefaultEndpointsProtocol=%s;AccountName=%s;AccountKey=%s",
+                config.getAzureDefaultEndpointsProtocol(),
+                config.getAzureAccountName(),
+                config.getAzureAccountKey());
+
+        try {
+            CloudStorageAccount storageAccount = CloudStorageAccount.parse(connectionString);
+            return storageAccount.createCloudBlobClient();
+        } catch (Exception e) {
+            throw new CustomException("AZURE_CLIENT_INITIALIZE_ERROR", e.getMessage());
+        }
+    }
+}

--- a/core-services/egov-malware-detection/src/main/java/org/egov/malware/config/MalwareDetectionConfig.java
+++ b/core-services/egov-malware-detection/src/main/java/org/egov/malware/config/MalwareDetectionConfig.java
@@ -55,6 +55,19 @@ public class MalwareDetectionConfig {
     @Value("${minio.source:minio}")
     private String minioSource;
 
+    // Azure Blob Storage Configuration (aligned with egov-filestore)
+    @Value("${isAzureStorageEnabled:false}")
+    private boolean azureStorageEnabled;
+
+    @Value("${azure.defaultEndpointsProtocol:https}")
+    private String azureDefaultEndpointsProtocol;
+
+    @Value("${azure.accountName:}")
+    private String azureAccountName;
+
+    @Value("${azure.accountKey:}")
+    private String azureAccountKey;
+
     // Filestore Configuration
     @Value("${egov.filestore.host}")
     private String filestoreHost;

--- a/core-services/egov-malware-detection/src/main/java/org/egov/malware/config/MinioClientConfig.java
+++ b/core-services/egov-malware-detection/src/main/java/org/egov/malware/config/MinioClientConfig.java
@@ -3,13 +3,13 @@ package org.egov.malware.config;
 import io.minio.MinioClient;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @Slf4j
-@ConditionalOnProperty(value = "isS3Enabled", havingValue = "true", matchIfMissing = true)
+@ConditionalOnExpression("${isS3Enabled:true} and !${isAzureStorageEnabled:false}")
 public class MinioClientConfig {
 
     @Autowired

--- a/core-services/egov-malware-detection/src/main/java/org/egov/malware/service/FileRetrievalService.java
+++ b/core-services/egov-malware-detection/src/main/java/org/egov/malware/service/FileRetrievalService.java
@@ -1,14 +1,12 @@
 package org.egov.malware.service;
 
-import io.minio.GetObjectArgs;
-import io.minio.MinioClient;
-import io.minio.StatObjectArgs;
-import io.minio.StatObjectResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.egov.malware.config.MalwareDetectionConfig;
 import org.egov.malware.model.FileInfo;
 import org.egov.malware.model.MalwareScanRequest;
+import org.egov.malware.storage.StorageClient;
+import org.egov.malware.storage.StorageObjectMetadata;
 import org.egov.tracer.model.CustomException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -21,12 +19,12 @@ import java.security.NoSuchAlgorithmException;
 @Slf4j
 public class FileRetrievalService {
 
-    private final MinioClient minioClient;
+    private final StorageClient storageClient;
     private final MalwareDetectionConfig config;
 
     @Autowired
-    public FileRetrievalService(MinioClient minioClient, MalwareDetectionConfig config) {
-        this.minioClient = minioClient;
+    public FileRetrievalService(StorageClient storageClient, MalwareDetectionConfig config) {
+        this.storageClient = storageClient;
         this.config = config;
     }
 
@@ -55,29 +53,18 @@ public class FileRetrievalService {
             String objectPath = getObjectPath(scanRequest);
             String bucketName = config.getMinioBucketName();
 
-            log.info("[FILE-RETRIEVAL] MinIO bucket: {}", bucketName);
+            log.info("[FILE-RETRIEVAL] Storage bucket/container: {}", bucketName);
             log.info("[FILE-RETRIEVAL] Object path: {}", objectPath);
-            log.info("[FILE-RETRIEVAL] MinIO URL: {}", config.getMinioUrl());
 
             // Get file metadata first
-            log.info("[FILE-RETRIEVAL] Getting file metadata from MinIO...");
-            StatObjectResponse statResponse = minioClient.statObject(
-                    StatObjectArgs.builder()
-                            .bucket(bucketName)
-                            .object(objectPath)
-                            .build()
-            );
+            log.info("[FILE-RETRIEVAL] Getting file metadata from storage...");
+            StorageObjectMetadata statResponse = storageClient.statObject(bucketName, objectPath);
             log.info("[FILE-RETRIEVAL] File metadata retrieved - size: {} bytes, contentType: {}",
-                    statResponse.size(), statResponse.contentType());
+                    statResponse.getSize(), statResponse.getContentType());
 
             // Get file content as stream
-            log.info("[FILE-RETRIEVAL] Downloading file content from MinIO...");
-            InputStream inputStream = minioClient.getObject(
-                    GetObjectArgs.builder()
-                            .bucket(bucketName)
-                            .object(objectPath)
-                            .build()
-            );
+            log.info("[FILE-RETRIEVAL] Downloading file content from storage...");
+            InputStream inputStream = storageClient.getObject(bucketName, objectPath);
 
             // Read content into byte array for scanning
             byte[] content = IOUtils.toByteArray(inputStream);
@@ -94,8 +81,8 @@ public class FileRetrievalService {
                     .tenantId(scanRequest.getTenantId())
                     .fileName(scanRequest.getFileName())
                     .filePath(objectPath)
-                    .contentType(statResponse.contentType())
-                    .fileSize(statResponse.size())
+                    .contentType(statResponse.getContentType())
+                    .fileSize(statResponse.getSize())
                     .fileHash(fileHash)
                     .fileSource(scanRequest.getFileSource())
                     .content(content)
@@ -124,26 +111,21 @@ public class FileRetrievalService {
     }
 
     /**
-     * Validates that the file source is supported.
-     * Currently only MinIO/S3 storage is supported.
+     * Validates the file source against the currently active storage backend.
+     * The active backend (MinIO/S3 vs Azure Blob Storage) is chosen at deploy time
+     * via isS3Enabled/isAzureStorageEnabled, so requests are expected to match it.
      *
      * @param fileSource   The storage backend identifier
      * @param fileStoreId  The file store ID for logging
      */
     private void validateFileSource(String fileSource, String fileStoreId) {
         if (fileSource == null || fileSource.isEmpty()) {
-            log.warn("File source not specified for fileStoreId: {}, assuming MinIO/S3", fileStoreId);
+            log.warn("File source not specified for fileStoreId: {}, using configured storage backend", fileStoreId);
             return;
         }
 
-        if (AZURE_SOURCE.equals(fileSource)) {
-            log.error("Azure Blob Storage is not supported by malware detection service - fileStoreId: {}", fileStoreId);
-            throw new CustomException("UNSUPPORTED_STORAGE",
-                    "Azure Blob Storage is not currently supported for malware scanning. Only MinIO/S3 storage is supported.");
-        }
-
-        if (!MINIO_SOURCE.equals(fileSource)) {
-            log.warn("Unknown file source '{}' for fileStoreId: {}, attempting MinIO/S3 retrieval", fileSource, fileStoreId);
+        if (!MINIO_SOURCE.equals(fileSource) && !AZURE_SOURCE.equals(fileSource)) {
+            log.warn("Unknown file source '{}' for fileStoreId: {}, attempting retrieval via configured storage backend", fileSource, fileStoreId);
         }
     }
 
@@ -206,12 +188,7 @@ public class FileRetrievalService {
     public byte[] getFileContent(String fileStoreId, String tenantId, String filePath) {
         log.debug("Getting file content for fileStoreId: {}", fileStoreId);
         try {
-            InputStream inputStream = minioClient.getObject(
-                    GetObjectArgs.builder()
-                            .bucket(config.getMinioBucketName())
-                            .object(filePath)
-                            .build()
-            );
+            InputStream inputStream = storageClient.getObject(config.getMinioBucketName(), filePath);
             byte[] content = IOUtils.toByteArray(inputStream);
             inputStream.close();
             return content;

--- a/core-services/egov-malware-detection/src/main/java/org/egov/malware/service/QuarantineService.java
+++ b/core-services/egov-malware-detection/src/main/java/org/egov/malware/service/QuarantineService.java
@@ -1,10 +1,10 @@
 package org.egov.malware.service;
 
-import io.minio.*;
 import lombok.extern.slf4j.Slf4j;
 import org.egov.malware.config.MalwareDetectionConfig;
 import org.egov.malware.model.FileInfo;
 import org.egov.malware.model.QuarantineResult;
+import org.egov.malware.storage.StorageClient;
 import org.egov.tracer.model.CustomException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -17,12 +17,12 @@ import java.time.format.DateTimeFormatter;
 @Slf4j
 public class QuarantineService {
 
-    private final MinioClient minioClient;
+    private final StorageClient storageClient;
     private final MalwareDetectionConfig config;
 
     @Autowired
-    public QuarantineService(MinioClient minioClient, MalwareDetectionConfig config) {
-        this.minioClient = minioClient;
+    public QuarantineService(StorageClient storageClient, MalwareDetectionConfig config) {
+        this.storageClient = storageClient;
         this.config = config;
     }
 
@@ -90,19 +90,9 @@ public class QuarantineService {
     private void ensureQuarantineBucketExists() throws Exception {
         String quarantineBucket = config.getQuarantineBucketName();
 
-        boolean bucketExists = minioClient.bucketExists(
-                BucketExistsArgs.builder()
-                        .bucket(quarantineBucket)
-                        .build()
-        );
-
-        if (!bucketExists) {
+        if (!storageClient.bucketExists(quarantineBucket)) {
             log.info("Creating quarantine bucket: {}", quarantineBucket);
-            minioClient.makeBucket(
-                    MakeBucketArgs.builder()
-                            .bucket(quarantineBucket)
-                            .build()
-            );
+            storageClient.makeBucket(quarantineBucket);
         }
     }
 
@@ -115,36 +105,15 @@ public class QuarantineService {
 
         ByteArrayInputStream inputStream = new ByteArrayInputStream(content);
 
-        minioClient.putObject(
-                PutObjectArgs.builder()
-                        .bucket(config.getQuarantineBucketName())
-                        .object(quarantinePath)
-                        .stream(inputStream, content.length, -1)
-                        .contentType(fileInfo.getContentType())
-                        .build()
-        );
+        storageClient.putObject(config.getQuarantineBucketName(), quarantinePath,
+                inputStream, content.length, fileInfo.getContentType());
     }
 
     private void deleteOriginalFile(FileInfo fileInfo) throws Exception {
-        minioClient.removeObject(
-                RemoveObjectArgs.builder()
-                        .bucket(config.getMinioBucketName())
-                        .object(fileInfo.getFilePath())
-                        .build()
-        );
+        storageClient.removeObject(config.getMinioBucketName(), fileInfo.getFilePath());
     }
 
     public boolean isQuarantined(String fileStoreId, String quarantinePath) {
-        try {
-            minioClient.statObject(
-                    StatObjectArgs.builder()
-                            .bucket(config.getQuarantineBucketName())
-                            .object(quarantinePath)
-                            .build()
-            );
-            return true;
-        } catch (Exception e) {
-            return false;
-        }
+        return storageClient.objectExists(config.getQuarantineBucketName(), quarantinePath);
     }
 }

--- a/core-services/egov-malware-detection/src/main/java/org/egov/malware/storage/AzureBlobStorageClient.java
+++ b/core-services/egov-malware-detection/src/main/java/org/egov/malware/storage/AzureBlobStorageClient.java
@@ -1,0 +1,84 @@
+package org.egov.malware.storage;
+
+import com.microsoft.azure.storage.StorageException;
+import com.microsoft.azure.storage.blob.BlobContainerPublicAccessType;
+import com.microsoft.azure.storage.blob.BlobRequestOptions;
+import com.microsoft.azure.storage.OperationContext;
+import com.microsoft.azure.storage.blob.CloudBlobClient;
+import com.microsoft.azure.storage.blob.CloudBlobContainer;
+import com.microsoft.azure.storage.blob.CloudBlockBlob;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+import java.io.InputStream;
+import java.net.URISyntaxException;
+
+@Service
+@Slf4j
+@ConditionalOnProperty(value = "isAzureStorageEnabled", havingValue = "true")
+public class AzureBlobStorageClient implements StorageClient {
+
+    private final CloudBlobClient cloudBlobClient;
+
+    @Autowired
+    public AzureBlobStorageClient(CloudBlobClient cloudBlobClient) {
+        this.cloudBlobClient = cloudBlobClient;
+    }
+
+    @Override
+    public StorageObjectMetadata statObject(String bucket, String objectPath) throws Exception {
+        CloudBlockBlob blob = getContainer(bucket).getBlockBlobReference(objectPath);
+        blob.downloadAttributes();
+        return StorageObjectMetadata.builder()
+                .size(blob.getProperties().getLength())
+                .contentType(blob.getProperties().getContentType())
+                .build();
+    }
+
+    @Override
+    public InputStream getObject(String bucket, String objectPath) throws Exception {
+        CloudBlockBlob blob = getContainer(bucket).getBlockBlobReference(objectPath);
+        return blob.openInputStream();
+    }
+
+    @Override
+    public void putObject(String bucket, String objectPath, InputStream content, long contentLength, String contentType) throws Exception {
+        CloudBlobContainer container = getContainer(bucket);
+        container.createIfNotExists(BlobContainerPublicAccessType.OFF, new BlobRequestOptions(), new OperationContext());
+        CloudBlockBlob blob = container.getBlockBlobReference(objectPath);
+        if (contentType != null) {
+            blob.getProperties().setContentType(contentType);
+        }
+        blob.upload(content, contentLength);
+    }
+
+    @Override
+    public void removeObject(String bucket, String objectPath) throws Exception {
+        getContainer(bucket).getBlockBlobReference(objectPath).deleteIfExists();
+    }
+
+    @Override
+    public boolean bucketExists(String bucket) throws Exception {
+        return getContainer(bucket).exists();
+    }
+
+    @Override
+    public void makeBucket(String bucket) throws Exception {
+        getContainer(bucket).createIfNotExists(BlobContainerPublicAccessType.OFF, new BlobRequestOptions(), new OperationContext());
+    }
+
+    @Override
+    public boolean objectExists(String bucket, String objectPath) {
+        try {
+            return getContainer(bucket).getBlockBlobReference(objectPath).exists();
+        } catch (StorageException | URISyntaxException e) {
+            return false;
+        }
+    }
+
+    private CloudBlobContainer getContainer(String bucket) throws URISyntaxException, StorageException {
+        return cloudBlobClient.getContainerReference(bucket);
+    }
+}

--- a/core-services/egov-malware-detection/src/main/java/org/egov/malware/storage/MinioStorageClient.java
+++ b/core-services/egov-malware-detection/src/main/java/org/egov/malware/storage/MinioStorageClient.java
@@ -1,0 +1,75 @@
+package org.egov.malware.storage;
+
+import io.minio.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.stereotype.Service;
+
+import java.io.InputStream;
+
+@Service
+@Slf4j
+@ConditionalOnExpression("${isS3Enabled:true} and !${isAzureStorageEnabled:false}")
+public class MinioStorageClient implements StorageClient {
+
+    private final MinioClient minioClient;
+
+    @Autowired
+    public MinioStorageClient(MinioClient minioClient) {
+        this.minioClient = minioClient;
+    }
+
+    @Override
+    public StorageObjectMetadata statObject(String bucket, String objectPath) throws Exception {
+        StatObjectResponse response = minioClient.statObject(
+                StatObjectArgs.builder().bucket(bucket).object(objectPath).build());
+        return StorageObjectMetadata.builder()
+                .size(response.size())
+                .contentType(response.contentType())
+                .build();
+    }
+
+    @Override
+    public InputStream getObject(String bucket, String objectPath) throws Exception {
+        return minioClient.getObject(
+                GetObjectArgs.builder().bucket(bucket).object(objectPath).build());
+    }
+
+    @Override
+    public void putObject(String bucket, String objectPath, InputStream content, long contentLength, String contentType) throws Exception {
+        minioClient.putObject(
+                PutObjectArgs.builder()
+                        .bucket(bucket)
+                        .object(objectPath)
+                        .stream(content, contentLength, -1)
+                        .contentType(contentType)
+                        .build());
+    }
+
+    @Override
+    public void removeObject(String bucket, String objectPath) throws Exception {
+        minioClient.removeObject(
+                RemoveObjectArgs.builder().bucket(bucket).object(objectPath).build());
+    }
+
+    @Override
+    public boolean bucketExists(String bucket) throws Exception {
+        return minioClient.bucketExists(BucketExistsArgs.builder().bucket(bucket).build());
+    }
+
+    @Override
+    public void makeBucket(String bucket) throws Exception {
+        minioClient.makeBucket(MakeBucketArgs.builder().bucket(bucket).build());
+    }
+
+    @Override
+    public boolean objectExists(String bucket, String objectPath) {
+        try {
+            minioClient.statObject(StatObjectArgs.builder().bucket(bucket).object(objectPath).build());
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/core-services/egov-malware-detection/src/main/java/org/egov/malware/storage/StorageClient.java
+++ b/core-services/egov-malware-detection/src/main/java/org/egov/malware/storage/StorageClient.java
@@ -1,0 +1,27 @@
+package org.egov.malware.storage;
+
+import java.io.InputStream;
+
+/**
+ * Abstraction over the object storage backend used to fetch scan targets and
+ * write quarantined files. Exactly one implementation is active at a time,
+ * selected via isS3Enabled / isAzureStorageEnabled:
+ * 1. MinIO/S3 ({@link MinioStorageClient})
+ * 2. Azure Blob Storage ({@link AzureBlobStorageClient})
+ */
+public interface StorageClient {
+
+    StorageObjectMetadata statObject(String bucket, String objectPath) throws Exception;
+
+    InputStream getObject(String bucket, String objectPath) throws Exception;
+
+    void putObject(String bucket, String objectPath, InputStream content, long contentLength, String contentType) throws Exception;
+
+    void removeObject(String bucket, String objectPath) throws Exception;
+
+    boolean bucketExists(String bucket) throws Exception;
+
+    void makeBucket(String bucket) throws Exception;
+
+    boolean objectExists(String bucket, String objectPath);
+}

--- a/core-services/egov-malware-detection/src/main/java/org/egov/malware/storage/StorageObjectMetadata.java
+++ b/core-services/egov-malware-detection/src/main/java/org/egov/malware/storage/StorageObjectMetadata.java
@@ -1,0 +1,13 @@
+package org.egov.malware.storage;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class StorageObjectMetadata {
+    private long size;
+    private String contentType;
+}

--- a/core-services/egov-malware-detection/src/main/resources/application.properties
+++ b/core-services/egov-malware-detection/src/main/resources/application.properties
@@ -40,6 +40,15 @@ fixed.bucket.region=ap-south-1
 quarantine.bucketname=egov-quarantine
 minio.source=minio
 
+# Azure Blob Storage Configuration (aligned with egov-filestore)
+# When isAzureStorageEnabled=true, the Azure Blob client is used instead of MinIO/S3,
+# and takes precedence over isS3Enabled. Container names reuse fixed.bucketname /
+# quarantine.bucketname above.
+isAzureStorageEnabled=false
+azure.defaultEndpointsProtocol=https
+azure.accountName=${AZURE_ACCOUNTNAME:}
+azure.accountKey=${AZURE_ACCOUNTKEY:}
+
 # Filestore Service Configuration
 egov.filestore.host=http://egov-filestore.egov:8080/
 egov.filestore.path=filestore/v1/files/id


### PR DESCRIPTION
## Summary
- `egov-malware-detection` currently only supports MinIO/S3 (`io.minio.MinioClient`) and explicitly rejects `AzureBlobStorage` as a file source (`FileRetrievalService.validateFileSource`), unlike `egov-filestore` which already supports both backends. This leaves Azure-based DIGIT deployments unable to run malware scanning at all - the app fails at scan time (or, if `MINIO_URL` is malformed, at Spring context startup).
- Adds a `StorageClient` abstraction (mirroring `egov-filestore`'s `CloudFilesManager` pattern) with two implementations selected via config flags:
  - `MinioStorageClient` - existing MinIO/S3 behavior, unchanged
  - `AzureBlobStorageClient` - new, using `com.microsoft.azure:azure-storage` (same SDK/version as `egov-filestore`), driven by `isAzureStorageEnabled` + `azure.accountName`/`azure.accountKey` (same property names as filestore, so the same secret can be reused)
- `FileRetrievalService` and `QuarantineService` now depend on `StorageClient` instead of `MinioClient` directly.
- Fixes a latent bug in `MinioClientConfig`: its `@ConditionalOnProperty(value = "isS3Enabled", havingValue = "true", matchIfMissing = true)` meant the Minio bean was built even when `isS3Enabled` was unset, with no way to actually disable it in favor of another backend. It's now `@ConditionalOnExpression("${isS3Enabled:true} and !${isAzureStorageEnabled:false}")`, ensuring exactly one storage client is ever active.

## Config additions
```
isAzureStorageEnabled=false
azure.defaultEndpointsProtocol=https
azure.accountName=${AZURE_ACCOUNTNAME:}
azure.accountKey=${AZURE_ACCOUNTKEY:}
```
Container names reuse the existing `fixed.bucketname` / `quarantine.bucketname` properties for both backends.

## Test plan
- [x] `mvn compile` passes (verified locally)
- [ ] Deploy with `isAzureStorageEnabled=true` against a real Azure Storage account and confirm scan requests with `fileSource=AzureBlobStorage` are retrieved, scanned, and quarantined correctly
- [ ] Confirm existing MinIO/S3 environments are unaffected (`isS3Enabled=true`, `isAzureStorageEnabled` unset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Azure Blob Storage support for malware detection file retrieval, quarantine, uploads, and deletions.
  * Added configuration options to enable Azure storage and provide account credentials.
  * Added automatic selection between Azure Blob Storage and MinIO based on configuration.

* **Bug Fixes**
  * Improved storage source handling so Azure-backed files are accepted and processed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->