### PR TITLE
[2.12] egov-enc-service: idempotent POST /crypto/v1/_generatekey

### DIFF
--- a/core-services/egov-enc-service/src/main/java/org/egov/enc/services/KeyManagementService.java
+++ b/core-services/egov-enc-service/src/main/java/org/egov/enc/services/KeyManagementService.java
@@ -142,6 +142,65 @@ public class KeyManagementService implements ApplicationRunner {
         return new RotateKeyResponse(true);
     }
 
+    /**
+     * Idempotently provision a symmetric + asymmetric key for a single tenantId.
+     *
+     * The default key-generation path (init() + checkIfTenantExists) only fires
+     * for tenants reachable via MDMS search under STATE_LEVEL_TENANT_ID — brand
+     * new state roots (which are not yet under any existing root's
+     * tenant.tenants list) get a "Tenant Id not found" 500 on first encrypt
+     * because no key exists for them.
+     *
+     * Callers that provision new tenants (e.g. MCP tenant_bootstrap) hit this
+     * BEFORE the first encrypt request for the new tenant. Re-issuing for an
+     * existing tenant is a no-op — the existing keyId is returned, no rotation.
+     *
+     * Synchronized to prevent two concurrent generates for the same fresh
+     * tenant from both inserting (the underlying generateKeys does not have
+     * an INSERT ... ON CONFLICT — duplicate rows would violate the keyId PK).
+     */
+    public synchronized org.egov.enc.web.models.GenerateKeyResponse generateKeyForTenant(String tenantId)
+            throws Exception {
+        if (tenantId == null || tenantId.trim().isEmpty()) {
+            throw new CustomException("INVALID_TENANT_ID", "tenantId must be non-empty");
+        }
+        final String normalized = tenantId.trim();
+
+        // Idempotency: if the tenant already has an active key in the store,
+        // return its keyId — do NOT generate a duplicate. This is the no-op
+        // path that lets callers issue this freely without worrying about state.
+        keyStore.refreshKeys();
+        if (keyStore.getTenantIds().contains(normalized)) {
+            org.egov.enc.models.SymmetricKey existing = keyStore.getSymmetricKey(normalized);
+            return org.egov.enc.web.models.GenerateKeyResponse.builder()
+                    .tenantId(normalized)
+                    .created(false)
+                    .keyId(existing != null ? existing.getId() : null)
+                    .build();
+        }
+
+        // Generate the key pair and persist. Reuses the same private path
+        // that init() and rotateAll() use — symmetric + asymmetric inserts
+        // in one shot; failure halfway throws and the caller can retry.
+        ArrayList<String> tenants = new ArrayList<>();
+        tenants.add(normalized);
+        generateKeys(tenants);
+
+        // Refresh in-memory caches so the next encrypt for this tenant
+        // resolves directly without going through the MDMS-discovery fallback.
+        keyStore.refreshKeys();
+        keyIdGenerator.refreshKeyIds();
+
+        org.egov.enc.models.SymmetricKey created = keyStore.getSymmetricKey(normalized);
+        log.info("Generated keys for tenantId={} (keyId={})", normalized,
+                created != null ? created.getId() : "?");
+        return org.egov.enc.web.models.GenerateKeyResponse.builder()
+                .tenantId(normalized)
+                .created(true)
+                .keyId(created != null ? created.getId() : null)
+                .build();
+    }
+
     public RotateKeyResponse rotateKey(RotateKeyRequest rotateKeyRequest) throws Exception {
         int status;
         status = keyRepository.deactivateSymmetricKeyForGivenTenant(rotateKeyRequest.getTenantId());

--- a/core-services/egov-enc-service/src/main/java/org/egov/enc/web/controllers/CryptoApiController.java
+++ b/core-services/egov-enc-service/src/main/java/org/egov/enc/web/controllers/CryptoApiController.java
@@ -70,4 +70,22 @@ public class CryptoApiController{
         return new ResponseEntity<RotateKeyResponse>(keyManagementService.rotateKey(rotateKeyRequest), HttpStatus.OK);
     }
 
+    /**
+     * Provision a symmetric + asymmetric key pair for a tenantId that doesn't
+     * have one yet. Idempotent — returns the existing keyId without rotating
+     * if the tenant already has a key.
+     *
+     * Required for new-state-root provisioning flows (MCP tenant_bootstrap,
+     * etc.) where the default MDMS-driven key discovery doesn't pick up the
+     * new tenant. Without this, the first encrypt for a brand-new tenant
+     * fails with "Tenant Id not found".
+     */
+    @RequestMapping(value = "/crypto/v1/_generatekey", method = RequestMethod.POST)
+    public ResponseEntity<GenerateKeyResponse> cryptoGenerateKey(
+            @Valid @RequestBody GenerateKeyRequest generateKeyRequest) throws Exception {
+        return new ResponseEntity<>(
+                keyManagementService.generateKeyForTenant(generateKeyRequest.getTenantId()),
+                HttpStatus.OK);
+    }
+
 }

--- a/core-services/egov-enc-service/src/main/java/org/egov/enc/web/models/GenerateKeyRequest.java
+++ b/core-services/egov-enc-service/src/main/java/org/egov/enc/web/models/GenerateKeyRequest.java
@@ -1,0 +1,31 @@
+package org.egov.enc.web.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Request body for POST /crypto/v1/_generatekey.
+ *
+ * Generates a symmetric + asymmetric key pair for the given tenantId if one
+ * doesn't already exist. Idempotent — re-issuing for an existing tenant
+ * returns the current keyId without rotating.
+ *
+ * Use case: callers that provision new tenants (e.g. MCP tenant_bootstrap)
+ * need a key to exist BEFORE the first encrypt request for that tenant.
+ * The default key-generation path (init() + checkIfTenantExists) only fires
+ * for tenants reachable via MDMS search under STATE_LEVEL_TENANT_ID, which
+ * excludes brand-new state roots.
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class GenerateKeyRequest {
+
+    @NotNull
+    @JsonProperty("tenantId")
+    private String tenantId;
+}

--- a/core-services/egov-enc-service/src/main/java/org/egov/enc/web/models/GenerateKeyResponse.java
+++ b/core-services/egov-enc-service/src/main/java/org/egov/enc/web/models/GenerateKeyResponse.java
@@ -1,0 +1,29 @@
+package org.egov.enc.web.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+/**
+ * Response from POST /crypto/v1/_generatekey.
+ *   created=true  → a new key was generated and persisted
+ *   created=false → tenant already had a key; this is a no-op
+ *
+ * The `keyId` is always populated on success (whether newly generated or
+ * pre-existing) so callers can correlate downstream encrypt requests.
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class GenerateKeyResponse {
+
+    @JsonProperty("tenantId")
+    private String tenantId;
+
+    @JsonProperty("created")
+    private boolean created;
+
+    @JsonProperty("keyId")
+    private Integer keyId;
+}


### PR DESCRIPTION
Adds an idempotent `POST /crypto/v1/_generatekey` endpoint to egov-enc-service so a tenant's encryption key can be provisioned on demand (needed for multi-tenant / SaaS onboarding where new tenants must self-provision keys).

- **Source:** `ChakshuGautam/Digit-Core@f5d272b` (`feat(egov-enc-service): add idempotent POST /crypto/v1/_generatekey endpoint`)
- Cherry-picked onto `2.12` (1 commit; the JDK21 lombok bump on the fork branch is intentionally excluded and belongs with the separate JDK21 runtime PR #1385).
- **Live on bomet** as image tag `egov-enc-service:generatekey-endpoint`.
