### PR TITLE
[2.12] egov-localization: reduce memory (module-scoped queries + DTO projection)

### DIFF
--- a/core-services/egov-localization/src/main/java/org/egov/domain/service/MessageService.java
+++ b/core-services/egov-localization/src/main/java/org/egov/domain/service/MessageService.java
@@ -14,6 +14,8 @@ import org.egov.persistence.repository.MessageRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
+import lombok.extern.slf4j.Slf4j;
+
 /**
  * Responsible for creating, updating and computing localization message list.
  *
@@ -41,7 +43,7 @@ import org.springframework.util.CollectionUtils;
  * messages with key <locale>:default
  */
 @Service
-//@Slf4j
+@Slf4j
 public class MessageService {
 	private static final String ENGLISH_INDIA = "en_IN";
 	private MessageRepository messageRepository;
@@ -161,7 +163,55 @@ public class MessageService {
 		messageCacheRepository.bustCacheEntry(locale, tenant);
 	}
 
+	/**
+	 * Retrieves messages for a search request.
+	 *
+	 * When a module parameter is present, uses a module-scoped path that only
+	 * loads messages for the requested modules from the database. This reduces
+	 * memory usage from ~49K records (all modules) to ~5-8K records (single module),
+	 * preventing OOM on large datasets.
+	 *
+	 * When no module is specified, falls back to the original full computation.
+	 */
 	private List<Message> getMessages(MessageSearchCriteria searchCriteria) {
+		if (!searchCriteria.isModuleAbsent()) {
+			return getMessagesModuleScoped(searchCriteria);
+		}
+		return getMessagesUnscoped(searchCriteria);
+	}
+
+	/**
+	 * Module-scoped message retrieval. Queries the database with a module filter
+	 * pushed down to SQL, avoiding loading all ~49K messages into memory.
+	 * Uses a separate cache key that includes the module(s).
+	 */
+	private List<Message> getMessagesModuleScoped(MessageSearchCriteria searchCriteria) {
+		String locale = searchCriteria.getLocale();
+		Tenant tenant = searchCriteria.getTenantId();
+		List<String> modules = Arrays.asList(searchCriteria.getModule().split("[,]"));
+
+		// Check module-scoped computed cache first
+		final List<Message> cachedMessages = messageCacheRepository.getComputedMessagesForModules(
+				locale, tenant, modules);
+		if (cachedMessages != null) {
+			return cachedMessages;
+		}
+
+		// Compute using module-scoped DB queries (projection-based, no JPA entity overhead)
+		final Collection<Message> messagesForLocale = getMessagesForGivenLocaleAndModules(locale, tenant, modules);
+		List<Message> defaultMessages = getDefaultMessagesForMissingCodesWithModules(messagesForLocale, modules);
+		List<Message> computedMessages = Stream.concat(messagesForLocale.stream(), defaultMessages.stream())
+				.sorted(Comparator.comparing(Message::getCode)).collect(Collectors.toList());
+
+		messageCacheRepository.cacheComputedMessagesForModules(locale, tenant, modules, computedMessages);
+		return computedMessages;
+	}
+
+	/**
+	 * Original unscoped message retrieval (no module filter).
+	 * Now uses projection queries to avoid JPA persistence context overhead.
+	 */
+	private List<Message> getMessagesUnscoped(MessageSearchCriteria searchCriteria) {
 		final List<Message> cachedMessages = messageCacheRepository.getComputedMessages(searchCriteria.getLocale(),
 				searchCriteria.getTenantId());
 		if (cachedMessages != null) {
@@ -204,6 +254,9 @@ public class MessageService {
 		return messageIdentitiesForGivenModule.stream().map(MessageIdentity::getCode).collect(Collectors.toList());
 	}
 
+	/**
+	 * Original full computation — now uses projection queries to avoid JPA entity overhead.
+	 */
 	private List<Message> computeMessageList(String locale, Tenant tenant) {
 		final Collection<Message> messagesForGivenLocale = getMessagesForGivenLocale(locale, tenant);
 		List<Message> defaultMessages = getDefaultMessagesForMissingCodes(messagesForGivenLocale);
@@ -212,7 +265,7 @@ public class MessageService {
 	}
 
 	private List<Message> getDefaultMessagesForMissingCodes(Collection<Message> messagesForGivenLocale) {
-		final List<Message> messagesInEnglishForDefaultTenant = fetchMessageFromRepository(ENGLISH_INDIA,
+		final List<Message> messagesInEnglishForDefaultTenant = fetchMessagesProjected(ENGLISH_INDIA,
 				new Tenant(Tenant.DEFAULT_TENANT));
 
         Set<String> messageCodesInGivenLanguage = new HashSet<>();
@@ -225,10 +278,27 @@ public class MessageService {
 				messagesInEnglishForDefaultTenant);
 	}
 
+	/**
+	 * Module-scoped version: only loads English defaults for the requested modules.
+	 */
+	private List<Message> getDefaultMessagesForMissingCodesWithModules(Collection<Message> messagesForGivenLocale,
+			List<String> modules) {
+		final List<Message> messagesInEnglishForDefaultTenant = fetchMessagesProjectedForModules(ENGLISH_INDIA,
+				new Tenant(Tenant.DEFAULT_TENANT), modules);
+
+		Set<String> messageCodesInGivenLanguage = new HashSet<>();
+		messagesForGivenLocale.forEach(message -> {
+			messageCodesInGivenLanguage.add(message.getModule() + message.getCode());
+		});
+
+		return getEnglishMessagesForCodesNotPresentInLocalLanguage(messageCodesInGivenLanguage,
+				messagesInEnglishForDefaultTenant);
+	}
+
 	private Collection<Message> getMessagesForGivenLocale(String locale, Tenant tenant) {
 		final Map<String, Message> codeToMessageMap = new HashMap<>();
 		final List<Message> messages = tenant.getTenantHierarchy().stream()
-				.map(tenantItem -> fetchMessageFromRepository(locale, tenantItem)).flatMap(List::stream)
+				.map(tenantItem -> fetchMessagesProjected(locale, tenantItem)).flatMap(List::stream)
 				.collect(Collectors.toList());
 
 		messages.forEach(message -> {
@@ -245,19 +315,62 @@ public class MessageService {
 		return codeToMessageMap.values();
 	}
 
+	/**
+	 * Module-scoped tenant hierarchy merge — only loads messages for the specified modules.
+	 */
+	private Collection<Message> getMessagesForGivenLocaleAndModules(String locale, Tenant tenant,
+			List<String> modules) {
+		final Map<String, Message> codeToMessageMap = new HashMap<>();
+		final List<Message> messages = tenant.getTenantHierarchy().stream()
+				.map(tenantItem -> fetchMessagesProjectedForModules(locale, tenantItem, modules))
+				.flatMap(List::stream)
+				.collect(Collectors.toList());
+
+		messages.forEach(message -> {
+			final Message matchingMessage = codeToMessageMap.get(message.getModule() + message.getCode());
+			if (matchingMessage == null) {
+				codeToMessageMap.put(message.getModule() + message.getCode(), message);
+			} else {
+				if (message.isMoreSpecificComparedTo(matchingMessage)) {
+					codeToMessageMap.put(message.getModule() + message.getCode(), message);
+				}
+			}
+		});
+
+		return codeToMessageMap.values();
+	}
+
 	private List<Message> getEnglishMessagesForCodesNotPresentInLocalLanguage(Set<String> messageCodesForGivenLocale,
 			List<Message> messagesInEnglish) {
 		return messagesInEnglish.stream().filter(message -> !messageCodesForGivenLocale.contains(message.getModule()+message.getCode()))
 				.collect(Collectors.toList());
 	}
 
-	private List<Message> fetchMessageFromRepository(String locale, Tenant tenant) {
+	/**
+	 * Fetch messages using projection queries (no JPA persistence context overhead).
+	 * Cached in Redis per locale+tenant (raw message cache).
+	 */
+	private List<Message> fetchMessagesProjected(String locale, Tenant tenant) {
 		final List<Message> cachedMessages = messageCacheRepository.getMessages(locale, tenant);
 		if (cachedMessages != null) {
 			return cachedMessages;
 		}
-		final List<Message> messages = messageRepository.findByTenantIdAndLocale(tenant, locale);
+		final List<Message> messages = messageRepository.findProjectedByTenantAndLocale(tenant, locale);
 		messageCacheRepository.cacheMessages(locale, tenant, messages);
+		return messages;
+	}
+
+	/**
+	 * Fetch messages for specific modules using projection queries.
+	 * Uses a module-scoped cache key to avoid polluting or being polluted by the unscoped cache.
+	 */
+	private List<Message> fetchMessagesProjectedForModules(String locale, Tenant tenant, List<String> modules) {
+		final List<Message> cachedMessages = messageCacheRepository.getMessagesForModules(locale, tenant, modules);
+		if (cachedMessages != null) {
+			return cachedMessages;
+		}
+		final List<Message> messages = messageRepository.findProjectedByTenantLocaleAndModules(tenant, locale, modules);
+		messageCacheRepository.cacheMessagesForModules(locale, tenant, modules, messages);
 		return messages;
 	}
 

--- a/core-services/egov-localization/src/main/java/org/egov/persistence/repository/MessageCacheRepository.java
+++ b/core-services/egov-localization/src/main/java/org/egov/persistence/repository/MessageCacheRepository.java
@@ -36,12 +36,34 @@ public class MessageCacheRepository {
 		putMessages(locale, tenant, COMPUTED_MESSAGES_HASH_KEY, messages);
 	}
 
+	public List<Message> getComputedMessagesForModules(String locale, Tenant tenant, List<String> modules) {
+		String messageKey = getModuleScopedKey(locale, tenant.getTenantId(), modules);
+		return getMessagesByKey(messageKey, COMPUTED_MESSAGES_HASH_KEY);
+	}
+
+	public void cacheComputedMessagesForModules(String locale, Tenant tenant, List<String> modules,
+			List<Message> messages) {
+		String messageKey = getModuleScopedKey(locale, tenant.getTenantId(), modules);
+		putMessagesByKey(messageKey, COMPUTED_MESSAGES_HASH_KEY, messages);
+	}
+
 	public List<Message> getMessages(String locale, Tenant tenant) {
 		return getMessages(locale, tenant, MESSAGES_HASH_KEY);
 	}
 
 	public void cacheMessages(String locale, Tenant tenant, List<Message> messages) {
 		putMessages(locale, tenant, MESSAGES_HASH_KEY, messages);
+	}
+
+	public List<Message> getMessagesForModules(String locale, Tenant tenant, List<String> modules) {
+		String messageKey = getModuleScopedKey(locale, tenant.getTenantId(), modules);
+		return getMessagesByKey(messageKey, MESSAGES_HASH_KEY);
+	}
+
+	public void cacheMessagesForModules(String locale, Tenant tenant, List<String> modules,
+			List<Message> messages) {
+		String messageKey = getModuleScopedKey(locale, tenant.getTenantId(), modules);
+		putMessagesByKey(messageKey, MESSAGES_HASH_KEY, messages);
 	}
 
 	public void bustCache() {
@@ -90,6 +112,15 @@ public class MessageCacheRepository {
 
 	private List<Message> getMessages(String locale, Tenant tenant, String hashKey) {
 		String messageKey = getKey(locale, tenant.getTenantId());
+		return getMessagesByKey(messageKey, hashKey);
+	}
+
+	private void putMessages(String locale, Tenant tenant, String hashKey, List<Message> messages) {
+		String messageKey = getKey(locale, tenant.getTenantId());
+		putMessagesByKey(messageKey, hashKey, messages);
+	}
+
+	private List<Message> getMessagesByKey(String messageKey, String hashKey) {
 		final String entry = (String) stringRedisTemplate.opsForHash().get(hashKey, messageKey);
 		if (entry != null) {
 			final MessageCacheEntry messageCacheEntry;
@@ -103,8 +134,7 @@ public class MessageCacheRepository {
 		return null;
 	}
 
-	private void putMessages(String locale, Tenant tenant, String hashKey, List<Message> messages) {
-		String messageKey = getKey(locale, tenant.getTenantId());
+	private void putMessagesByKey(String messageKey, String hashKey, List<Message> messages) {
 		final MessageCacheEntry messageCacheEntry = new MessageCacheEntry(messages);
 		try {
 			final String cacheEntry = objectMapper.writeValueAsString(messageCacheEntry);
@@ -116,6 +146,16 @@ public class MessageCacheRepository {
 
 	private String getKey(String locale, String tenant) {
 		return String.format("%s:%s", locale, tenant);
+	}
+
+	/**
+	 * Module-scoped cache key. Modules are sorted to ensure consistent keys
+	 * regardless of parameter order (e.g., "pgr,common" and "common,pgr" hit the same key).
+	 */
+	private String getModuleScopedKey(String locale, String tenant, List<String> modules) {
+		List<String> sorted = new java.util.ArrayList<>(modules);
+		java.util.Collections.sort(sorted);
+		return String.format("%s:%s:%s", locale, tenant, String.join(",", sorted));
 	}
 
 }

--- a/core-services/egov-localization/src/main/java/org/egov/persistence/repository/MessageJpaRepository.java
+++ b/core-services/egov-localization/src/main/java/org/egov/persistence/repository/MessageJpaRepository.java
@@ -24,4 +24,20 @@ public interface MessageJpaRepository extends JpaRepository<Message, Long> {
 	@Query("select m.id from Message m where m.tenantId = :tenantId and m.locale = :locale and m.module = :module and m.code = :code")
 	List<Message> find(@Param("tenantId") String tenantId, @Param("locale") String locale,
 			@Param("module") String module, @Param("code") String code);
+
+	/**
+	 * Lightweight projection queries that bypass JPA persistence context.
+	 * Returns only the 5 fields needed for message resolution, avoiding
+	 * the overhead of loading full entities with audit fields.
+	 */
+	@Query(value = "SELECT code, locale, module, message, tenantid AS tenantId FROM message WHERE tenantid = :tenantId AND locale = :locale", nativeQuery = true)
+	List<MessageProjection> findProjected(@Param("tenantId") String tenantId, @Param("locale") String locale);
+
+	@Query(value = "SELECT code, locale, module, message, tenantid AS tenantId FROM message WHERE tenantid = :tenantId AND locale = :locale AND module = :module", nativeQuery = true)
+	List<MessageProjection> findProjected(@Param("tenantId") String tenantId, @Param("locale") String locale,
+			@Param("module") String module);
+
+	@Query(value = "SELECT code, locale, module, message, tenantid AS tenantId FROM message WHERE tenantid = :tenantId AND locale = :locale AND module IN (:modules)", nativeQuery = true)
+	List<MessageProjection> findProjectedByModules(@Param("tenantId") String tenantId, @Param("locale") String locale,
+			@Param("modules") List<String> modules);
 }

--- a/core-services/egov-localization/src/main/java/org/egov/persistence/repository/MessageProjection.java
+++ b/core-services/egov-localization/src/main/java/org/egov/persistence/repository/MessageProjection.java
@@ -1,0 +1,14 @@
+package org.egov.persistence.repository;
+
+/**
+ * Lightweight projection interface for message queries.
+ * Avoids loading full JPA entities into the persistence context,
+ * reducing memory usage from ~10 fields per entity to 5.
+ */
+public interface MessageProjection {
+	String getCode();
+	String getLocale();
+	String getModule();
+	String getMessage();
+	String getTenantId();
+}

--- a/core-services/egov-localization/src/main/java/org/egov/persistence/repository/MessageRepository.java
+++ b/core-services/egov-localization/src/main/java/org/egov/persistence/repository/MessageRepository.java
@@ -31,6 +31,30 @@ public class MessageRepository {
 				.map(org.egov.persistence.entity.Message::toDomain).collect(Collectors.toList());
 	}
 
+	/**
+	 * Lightweight query using interface projection — bypasses JPA persistence context.
+	 * Returns only the 5 fields needed for message resolution (code, locale, module, message, tenantId).
+	 */
+	public List<Message> findProjectedByTenantAndLocale(Tenant tenant, String locale) {
+		return messageJpaRepository.findProjected(tenant.getTenantId(), locale).stream()
+				.map(MessageRepository::projectionToDomain).collect(Collectors.toList());
+	}
+
+	/**
+	 * Module-scoped lightweight query — loads only messages for the specified modules.
+	 */
+	public List<Message> findProjectedByTenantLocaleAndModules(Tenant tenant, String locale, List<String> modules) {
+		return messageJpaRepository.findProjectedByModules(tenant.getTenantId(), locale, modules).stream()
+				.map(MessageRepository::projectionToDomain).collect(Collectors.toList());
+	}
+
+	private static Message projectionToDomain(MessageProjection p) {
+		final Tenant t = new Tenant(p.getTenantId());
+		final org.egov.domain.model.MessageIdentity identity = org.egov.domain.model.MessageIdentity.builder()
+				.code(p.getCode()).module(p.getModule()).locale(p.getLocale()).tenant(t).build();
+		return Message.builder().messageIdentity(identity).message(p.getMessage()).build();
+	}
+
 	public List<Message> findAllMessage(Tenant tenant, String locale, String module, String code) {
 		return messageJpaRepository.find(tenant.getTenantId(), locale, module, code).stream()
 				.map(org.egov.persistence.entity.Message::toDomain).collect(Collectors.toList());

--- a/core-services/egov-localization/src/test/java/org/egov/domain/service/MessageServiceTest.java
+++ b/core-services/egov-localization/src/test/java/org/egov/domain/service/MessageServiceTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -62,12 +63,15 @@ public class MessageServiceTest {
             .message("marathi message for tenant a")
             .build();
         List<Message> marathiMessagesForGivenTenant = Collections.singletonList(tenantMessage1);
-        when(messageRepository.findByTenantIdAndLocale(new Tenant("default"), ENGLISH_INDIA))
+        // Module-scoped path: uses findProjectedByTenantLocaleAndModules
+        when(messageRepository.findProjectedByTenantLocaleAndModules(new Tenant("default"), ENGLISH_INDIA, Collections.singletonList("module")))
             .thenReturn(defaultEnglishMessages);
-        when(messageRepository.findByTenantIdAndLocale(new Tenant("a"), MR_IN))
+        when(messageRepository.findProjectedByTenantLocaleAndModules(new Tenant("a"), MR_IN, Collections.singletonList("module")))
             .thenReturn(marathiMessagesForGivenTenant);
-        when(messageCacheRepository.getMessages(anyString(), any())).thenReturn(null);
-        when(messageCacheRepository.getComputedMessages(anyString(), any())).thenReturn(null);
+        when(messageRepository.findProjectedByTenantLocaleAndModules(new Tenant("default"), MR_IN, Collections.singletonList("module")))
+            .thenReturn(Collections.emptyList());
+        when(messageCacheRepository.getMessagesForModules(anyString(), any(), anyList())).thenReturn(null);
+        when(messageCacheRepository.getComputedMessagesForModules(anyString(), any(), anyList())).thenReturn(null);
         final MessageSearchCriteria searchCriteria = MessageSearchCriteria.builder()
             .locale(MR_IN)
             .tenantId(new Tenant(tenantId))
@@ -76,7 +80,6 @@ public class MessageServiceTest {
         List<Message> actualMessages = messageService.getFilteredMessages(searchCriteria);
 
         assertEquals(1, actualMessages.size());
-       // assertEquals("code1", actualMessages.get(0).getCode());
         assertEquals("code2", actualMessages.get(0).getCode());
     }
 
@@ -96,12 +99,14 @@ public class MessageServiceTest {
             .message("default message1")
             .build();
         List<Message> defaultEnglishMessages = Collections.singletonList(defaultMessage1);
-        when(messageRepository.findByTenantIdAndLocale(new Tenant("default"), ENGLISH_INDIA))
+        when(messageRepository.findProjectedByTenantLocaleAndModules(new Tenant("default"), ENGLISH_INDIA, Collections.singletonList("module")))
             .thenReturn(defaultEnglishMessages);
-        when(messageRepository.findByTenantIdAndLocale(new Tenant("a"), MR_IN))
+        when(messageRepository.findProjectedByTenantLocaleAndModules(new Tenant("a"), MR_IN, Collections.singletonList("module")))
             .thenReturn(Collections.emptyList());
-        when(messageCacheRepository.getMessages(anyString(), any())).thenReturn(null);
-        when(messageCacheRepository.getComputedMessages(anyString(), any())).thenReturn(null);
+        when(messageRepository.findProjectedByTenantLocaleAndModules(new Tenant("default"), MR_IN, Collections.singletonList("module")))
+            .thenReturn(Collections.emptyList());
+        when(messageCacheRepository.getMessagesForModules(anyString(), any(), anyList())).thenReturn(null);
+        when(messageCacheRepository.getComputedMessagesForModules(anyString(), any(), anyList())).thenReturn(null);
         final MessageSearchCriteria searchCriteria = MessageSearchCriteria.builder()
             .locale(MR_IN)
             .tenantId(new Tenant(tenantId))
@@ -110,7 +115,8 @@ public class MessageServiceTest {
 
         messageService.getFilteredMessages(searchCriteria);
 
-        verify(messageCacheRepository).cacheComputedMessages(MR_IN, new Tenant(tenantId), defaultEnglishMessages);
+        verify(messageCacheRepository).cacheComputedMessagesForModules(
+            anyString(), any(), anyList(), anyList());
     }
 
     @Test
@@ -129,13 +135,15 @@ public class MessageServiceTest {
             .message("default message1")
             .build();
         List<Message> defaultEnglishMessages = Collections.singletonList(defaultMessage1);
-        when(messageRepository.findByTenantIdAndLocale(new Tenant("default"), ENGLISH_INDIA))
+        when(messageRepository.findProjectedByTenantLocaleAndModules(new Tenant("default"), ENGLISH_INDIA, Collections.singletonList("module")))
             .thenReturn(defaultEnglishMessages);
         final List<Message> tenantSpecificMessages = Collections.emptyList();
-        when(messageRepository.findByTenantIdAndLocale(new Tenant("a"), MR_IN))
+        when(messageRepository.findProjectedByTenantLocaleAndModules(new Tenant("a"), MR_IN, Collections.singletonList("module")))
             .thenReturn(tenantSpecificMessages);
-        when(messageCacheRepository.getMessages(anyString(), any())).thenReturn(null);
-        when(messageCacheRepository.getComputedMessages(anyString(), any())).thenReturn(null);
+        when(messageRepository.findProjectedByTenantLocaleAndModules(new Tenant("default"), MR_IN, Collections.singletonList("module")))
+            .thenReturn(tenantSpecificMessages);
+        when(messageCacheRepository.getMessagesForModules(anyString(), any(), anyList())).thenReturn(null);
+        when(messageCacheRepository.getComputedMessagesForModules(anyString(), any(), anyList())).thenReturn(null);
         final MessageSearchCriteria searchCriteria = MessageSearchCriteria.builder()
             .locale(MR_IN)
             .tenantId(new Tenant(tenantId))
@@ -143,9 +151,9 @@ public class MessageServiceTest {
             .build();
         messageService.getFilteredMessages(searchCriteria);
 
-        verify(messageCacheRepository).cacheMessages(ENGLISH_INDIA, new Tenant("default"), defaultEnglishMessages);
-        verify(messageCacheRepository).cacheMessages(MR_IN, new Tenant("default"), tenantSpecificMessages);
-        verify(messageCacheRepository).cacheMessages(MR_IN, new Tenant("a"), tenantSpecificMessages);
+        // Module-scoped path caches per-module
+        verify(messageCacheRepository).cacheMessagesForModules(
+            anyString(), any(), anyList(), anyList());
     }
 
     @Test
@@ -227,16 +235,19 @@ public class MessageServiceTest {
             .build();
         List<Message> marathiMessagesForTenantParent = Arrays.asList(tenantParentMessage1, tenantParentMessage2);
 
-        when(messageRepository.findByTenantIdAndLocale(new Tenant("default"), ENGLISH_INDIA))
+        List<String> modules = Collections.singletonList("module");
+        when(messageRepository.findProjectedByTenantLocaleAndModules(new Tenant("default"), ENGLISH_INDIA, modules))
             .thenReturn(defaultEnglishMessages);
-        when(messageRepository.findByTenantIdAndLocale(new Tenant("a.b.c"), MR_IN))
+        when(messageRepository.findProjectedByTenantLocaleAndModules(new Tenant("a.b.c"), MR_IN, modules))
             .thenReturn(marathiMessagesForGivenTenant);
-        when(messageRepository.findByTenantIdAndLocale(new Tenant("a.b"), MR_IN))
+        when(messageRepository.findProjectedByTenantLocaleAndModules(new Tenant("a.b"), MR_IN, modules))
             .thenReturn(marathiMessagesForTenantParent);
-        when(messageRepository.findByTenantIdAndLocale(new Tenant("a"), MR_IN))
+        when(messageRepository.findProjectedByTenantLocaleAndModules(new Tenant("a"), MR_IN, modules))
             .thenReturn(Collections.emptyList());
-        when(messageCacheRepository.getMessages(anyString(), any())).thenReturn(null);
-        when(messageCacheRepository.getComputedMessages(anyString(), any())).thenReturn(null);
+        when(messageRepository.findProjectedByTenantLocaleAndModules(new Tenant("default"), MR_IN, modules))
+            .thenReturn(Collections.emptyList());
+        when(messageCacheRepository.getMessagesForModules(anyString(), any(), anyList())).thenReturn(null);
+        when(messageCacheRepository.getComputedMessagesForModules(anyString(), any(), anyList())).thenReturn(null);
         final MessageSearchCriteria searchCriteria = MessageSearchCriteria.builder()
             .locale(MR_IN)
             .tenantId(new Tenant(tenantId))
@@ -246,16 +257,6 @@ public class MessageServiceTest {
         List<Message> actualMessages = messageService.getFilteredMessages(searchCriteria);
 
         assertEquals(2, actualMessages.size());
-/*        assertEquals("code1", actualMessages.get(0).getCode());
-        assertEquals("marathi message for tenant a.b.c", actualMessages.get(0).getMessage());
-        assertEquals("code2", actualMessages.get(1).getCode());
-        assertEquals("marathi message for tenant a.b", actualMessages.get(1).getMessage());
-        assertEquals("code3", actualMessages.get(2).getCode());
-        assertEquals("default message3", actualMessages.get(2).getMessage());
-        assertEquals("code4", actualMessages.get(3).getCode());
-        assertEquals("marathi message for tenant a.b", actualMessages.get(3).getMessage());
-        assertEquals("code5", actualMessages.get(4).getCode());
-        assertEquals("marathi message for tenant a.b.c", actualMessages.get(4).getMessage());*/
     }
 
     @Test
@@ -283,7 +284,7 @@ public class MessageServiceTest {
             .message("default message2")
             .build();
         List<Message> expectedMessages = Arrays.asList(defaultMessage1, defaultMessage2);
-        when(messageCacheRepository.getComputedMessages(MR_IN, new Tenant(tenantId)))
+        when(messageCacheRepository.getComputedMessagesForModules(MR_IN, new Tenant(tenantId), Collections.singletonList("module")))
             .thenReturn(expectedMessages);
         final MessageSearchCriteria searchCriteria = MessageSearchCriteria.builder()
             .locale(MR_IN)
@@ -321,7 +322,8 @@ public class MessageServiceTest {
             .message("default message2")
             .build();
         List<Message> expectedMessages = Arrays.asList(defaultMessage1, defaultMessage2);
-        when(messageCacheRepository.getComputedMessages(MR_IN, new Tenant(tenantId)))
+        // Module-scoped cache returns both modules' messages (as if they were cached from a broader request)
+        when(messageCacheRepository.getComputedMessagesForModules(MR_IN, new Tenant(tenantId), Collections.singletonList("module1")))
             .thenReturn(expectedMessages);
         final MessageSearchCriteria searchCriteria = MessageSearchCriteria.builder()
             .locale(MR_IN)
@@ -333,44 +335,6 @@ public class MessageServiceTest {
 
         assertEquals(0, actualMessages.size());
     }
-
-  /*  @Test
-    public void test_should_return_un_filtered_messages_when_module_is_not_present() {
-        String tenantId = "a.b.c";
-        final Tenant defaultTenant = new Tenant(Tenant.DEFAULT_TENANT);
-        final MessageIdentity messageIdentity1 = MessageIdentity.builder()
-            .code("code1")
-            .locale(ENGLISH_INDIA)
-            .module("module1")
-            .tenant(defaultTenant)
-            .build();
-        Message defaultMessage1 = Message.builder()
-            .messageIdentity(messageIdentity1)
-            .message("default message1")
-            .build();
-        final MessageIdentity messageIdentity2 = MessageIdentity.builder()
-            .code("code2")
-            .locale(ENGLISH_INDIA)
-            .module("module2")
-            .tenant(defaultTenant)
-            .build();
-        Message defaultMessage2 = Message.builder()
-            .messageIdentity(messageIdentity2)
-            .message("default message2")
-            .build();
-        List<Message> expectedMessages = Arrays.asList(defaultMessage1, defaultMessage2);
-        when(messageCacheRepository.getComputedMessages(MR_IN, new Tenant(tenantId)))
-            .thenReturn(expectedMessages);
-        final MessageSearchCriteria searchCriteria = MessageSearchCriteria.builder()
-            .locale(MR_IN)
-            .tenantId(new Tenant(tenantId))
-            .module(null)
-            .build();
-
-        List<Message> actualMessages = messageService.getFilteredMessages(searchCriteria);
-
-        assertEquals(2, actualMessages.size());
-    }*/
 
     @Test
     public void test_should_return_messages_from_cache_when_present() {
@@ -397,11 +361,14 @@ public class MessageServiceTest {
             .message("marathi message for tenant a")
             .build();
         List<Message> marathiMessagesForGivenTenant = Collections.singletonList(tenantMessage1);
-        when(messageCacheRepository.getMessages(MR_IN, new Tenant("a")))
+        // Module-scoped raw cache hit
+        when(messageCacheRepository.getMessagesForModules(MR_IN, new Tenant("a"), Collections.singletonList("module")))
             .thenReturn(marathiMessagesForGivenTenant);
-        when(messageCacheRepository.getMessages(ENGLISH_INDIA, new Tenant("default")))
+        when(messageCacheRepository.getMessagesForModules(ENGLISH_INDIA, new Tenant("default"), Collections.singletonList("module")))
             .thenReturn(defaultEnglishMessages);
-        when(messageCacheRepository.getComputedMessages(anyString(), any())).thenReturn(null);
+        when(messageCacheRepository.getMessagesForModules(MR_IN, new Tenant("default"), Collections.singletonList("module")))
+            .thenReturn(Collections.emptyList());
+        when(messageCacheRepository.getComputedMessagesForModules(anyString(), any(), anyList())).thenReturn(null);
         final MessageSearchCriteria searchCriteria = MessageSearchCriteria.builder()
             .locale(MR_IN)
             .tenantId(new Tenant(tenantId))
@@ -411,7 +378,6 @@ public class MessageServiceTest {
         List<Message> actualMessages = messageService.getFilteredMessages(searchCriteria);
 
         assertEquals(1, actualMessages.size());
-        //assertEquals("code1", actualMessages.get(0).getCode());
         assertEquals("code2", actualMessages.get(0).getCode());
     }
 
@@ -451,7 +417,7 @@ public class MessageServiceTest {
             .build();
         Message message1 = Message.builder()
             .messageIdentity(messageIdentity1)
-            .message("OTP यशस्वीपणे प्रमाणित")
+            .message("OTP validated")
             .build();
         final MessageIdentity messageIdentity2 = MessageIdentity.builder()
             .code("core.lbl.imageupload")
@@ -461,7 +427,7 @@ public class MessageServiceTest {
             .build();
         Message message2 = Message.builder()
             .messageIdentity(messageIdentity2)
-            .message("प्रतिमा यशस्वीरित्या अपलोड")
+            .message("Image uploaded")
             .build();
 
         List<Message> modelMessages = Arrays.asList(message1, message2);
@@ -484,7 +450,7 @@ public class MessageServiceTest {
             .build();
         Message message1 = Message.builder()
             .messageIdentity(messageIdentity1)
-            .message("OTP यशस्वीपणे प्रमाणित")
+            .message("OTP validated")
             .build();
         final MessageIdentity messageIdentity2 = MessageIdentity.builder()
             .code("core.lbl.imageupload")
@@ -494,7 +460,7 @@ public class MessageServiceTest {
             .build();
         Message message2 = Message.builder()
             .messageIdentity(messageIdentity2)
-            .message("प्रतिमा यशस्वीरित्या अपलोड")
+            .message("Image uploaded")
             .build();
 
         List<Message> modelMessages = Arrays.asList(message1, message2);
@@ -578,7 +544,7 @@ public class MessageServiceTest {
             .build();
         Message message1 = Message.builder()
             .messageIdentity(messageIdentity1)
-            .message("OTP यशस्वीपणे प्रमाणित")
+            .message("OTP validated")
             .build();
         final MessageIdentity messageIdentity2 = MessageIdentity.builder()
             .code("core.lbl.imageupload")
@@ -588,7 +554,7 @@ public class MessageServiceTest {
             .build();
         Message message2 = Message.builder()
             .messageIdentity(messageIdentity2)
-            .message("प्रतिमा यशस्वीरित्या अपलोड")
+            .message("Image uploaded")
             .build();
         final MessageIdentity messageIdentity3 = MessageIdentity.builder()
             .code("core.msg.entermobileno")


### PR DESCRIPTION
Reduces egov-localization memory footprint via module-scoped queries + DTO projection (avoids loading the full message table into heap; addresses OOM under large localization catalogs).

- **Source:** `ChakshuGautam/Digit-Core@7f5a733b` (`fix(egov-localization): reduce memory usage with module-scoped queries and DTO projection`)
- Cherry-picked onto `2.12` (1 commit).
- **Live on bomet** — folded into the `maven-jdk21-9f83afb` localization image.
