### PR TITLE
[2.12] boundary-service: fix tenant filtering + tree assembly in relationship search

### DIFF
--- a/core-services/boundary-service/src/main/java/digit/repository/querybuilder/BoundaryRelationshipQueryBuilder.java
+++ b/core-services/boundary-service/src/main/java/digit/repository/querybuilder/BoundaryRelationshipQueryBuilder.java
@@ -57,10 +57,9 @@ public class BoundaryRelationshipQueryBuilder {
             }
         }
 
-        if(boundaryRelationshipSearchCriteria.getIsSearchForRootNode()) {
-            QueryUtil.addClauseIfRequired(builder, preparedStmtList);
-            builder.append(" parent IS NULL ");
-        }
+        // When isSearchForRootNode is true, fetch ALL nodes for the tenant+hierarchy
+        // so the enricher can build the full tree. Do NOT restrict to parent IS NULL,
+        // as that returns only root nodes with no children to assemble.
 
         if(!CollectionUtils.isEmpty(boundaryRelationshipSearchCriteria.getCurrentBoundaryCodes())) {
             QueryUtil.addClauseIfRequired(builder, preparedStmtList);

--- a/core-services/boundary-service/src/main/java/digit/web/controllers/BoundaryRelationshipController.java
+++ b/core-services/boundary-service/src/main/java/digit/web/controllers/BoundaryRelationshipController.java
@@ -4,7 +4,6 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import digit.service.BoundaryRelationshipService;
 import digit.web.models.*;
-import org.egov.common.contract.request.RequestInfo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -35,13 +34,13 @@ public class BoundaryRelationshipController {
 
     /**
      * Request handler for serving boundary relationships search request.
-     * @param boundaryRelationshipSearchCriteria
-     * @param requestInfo
+     * @param body wrapper containing RequestInfo and BoundaryRelationshipSearchCriteria
      * @return
      */
     @RequestMapping(value = "/_search", method = RequestMethod.POST)
-    public ResponseEntity<BoundarySearchResponse> search(@Valid @ModelAttribute BoundaryRelationshipSearchCriteria boundaryRelationshipSearchCriteria, @RequestBody RequestInfo requestInfo) {
-        BoundarySearchResponse boundarySearchResponse = boundaryRelationshipService.getBoundaryRelationships(boundaryRelationshipSearchCriteria, requestInfo);
+    public ResponseEntity<BoundarySearchResponse> search(@Valid @RequestBody BoundaryRelationshipSearchRequest body) {
+        BoundarySearchResponse boundarySearchResponse = boundaryRelationshipService.getBoundaryRelationships(
+                body.getBoundaryRelationshipSearchCriteria(), body.getRequestInfo());
         return new ResponseEntity<>(boundarySearchResponse, HttpStatus.OK);
     }
 

--- a/core-services/boundary-service/src/main/java/digit/web/models/BoundaryRelationshipSearchRequest.java
+++ b/core-services/boundary-service/src/main/java/digit/web/models/BoundaryRelationshipSearchRequest.java
@@ -1,0 +1,32 @@
+package digit.web.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.egov.common.contract.request.RequestInfo;
+import org.springframework.validation.annotation.Validated;
+
+import jakarta.validation.Valid;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Data;
+import lombok.Builder;
+
+/**
+ * Wrapper request for boundary relationship search — contains RequestInfo and search criteria.
+ */
+@Validated
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class BoundaryRelationshipSearchRequest {
+
+    @JsonProperty("RequestInfo")
+    @Valid
+    private RequestInfo requestInfo = null;
+
+    @JsonProperty("BoundaryRelationship")
+    @Valid
+    private BoundaryRelationshipSearchCriteria boundaryRelationshipSearchCriteria = null;
+
+}


### PR DESCRIPTION
Fixes tenant filtering and tree assembly in boundary-service relationship search (correct `tenantId` predicate + a typed `BoundaryRelationshipSearchRequest`), so relationship search returns the right subtree for the requested tenant.

- **Source:** `ChakshuGautam/Digit-Core@cfe19232` (`fix(boundary-service): fix tenant filtering and tree assembly in relationship search`)
- Cherry-picked onto `2.12` (1 commit).
- **Live on bomet** — folded into the `maven-jdk21-9f83afb` boundary-service image.
