### PR TITLE
[2.12] egov-workflow-v2: persist assignees on self-loop ASSIGN transitions

### DIFF
--- a/core-services/egov-workflow-v2/src/main/java/org/egov/wf/web/models/ProcessInstance.java
+++ b/core-services/egov-workflow-v2/src/main/java/org/egov/wf/web/models/ProcessInstance.java
@@ -10,6 +10,7 @@ import javax.validation.constraints.Size;
 import org.egov.common.contract.request.User;
 import org.springframework.validation.annotation.Validated;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.swagger.annotations.ApiModel;
@@ -80,7 +81,12 @@ public class ProcessInstance   {
         @JsonProperty("assigner")
         private User assigner = null;
 
+        // "assignes" is the historical (misspelled) contract key; serialization must
+        // keep emitting it because the persister jsonPaths (ProcessInstances.*.assignes.*)
+        // and downstream consumers depend on it. The alias accepts the correctly spelled
+        // "assignees" that some clients send, which was previously dropped silently.
         @JsonProperty("assignes")
+        @JsonAlias("assignees")
         private List<User> assignes = null;
 
         @JsonProperty("nextActions")

--- a/core-services/egov-workflow-v2/src/test/java/org/egov/wf/web/models/ProcessInstanceTest.java
+++ b/core-services/egov-workflow-v2/src/test/java/org/egov/wf/web/models/ProcessInstanceTest.java
@@ -1,0 +1,78 @@
+package org.egov.wf.web.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Collections;
+
+import org.egov.common.contract.request.User;
+import org.junit.jupiter.api.Test;
+
+class ProcessInstanceTest {
+
+    /**
+     * Mimics Spring Boot's default ObjectMapper, which has
+     * FAIL_ON_UNKNOWN_PROPERTIES disabled. Before the @JsonAlias fix this
+     * caused the correctly spelled "assignees" key to be dropped silently,
+     * so the transition was accepted with 200 but no eg_wf_assignee_v2 rows
+     * were ever persisted.
+     */
+    private ObjectMapper springBootLikeMapper() {
+        return new ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    }
+
+    @Test
+    void deserializesMisspelledContractKeyAssignes() throws Exception {
+        ProcessInstance processInstance = springBootLikeMapper()
+                .readValue("{\"assignes\":[{\"uuid\":\"u1\"}]}", ProcessInstance.class);
+
+        assertNotNull(processInstance.getAssignes());
+        assertEquals(1, processInstance.getAssignes().size());
+        assertEquals("u1", processInstance.getAssignes().get(0).getUuid());
+    }
+
+    @Test
+    void deserializesCorrectlySpelledAliasAssignees() throws Exception {
+        ProcessInstance processInstance = springBootLikeMapper()
+                .readValue("{\"assignees\":[{\"uuid\":\"u1\"}]}", ProcessInstance.class);
+
+        assertNotNull(processInstance.getAssignes());
+        assertEquals(1, processInstance.getAssignes().size());
+        assertEquals("u1", processInstance.getAssignes().get(0).getUuid());
+    }
+
+    @Test
+    void deserializesAliasInsideTransitionRequestPayload() throws Exception {
+        String payload = "{\"ProcessInstances\":[{\"tenantId\":\"pg.citya\","
+                + "\"businessService\":\"PGR\",\"businessId\":\"PG-PGR-2026-000001\","
+                + "\"action\":\"ASSIGN\",\"moduleName\":\"RAINMAKER-PGR\","
+                + "\"assignees\":[{\"uuid\":\"u1\"}]}]}";
+
+        ProcessInstanceRequest request = springBootLikeMapper()
+                .readValue(payload, ProcessInstanceRequest.class);
+
+        ProcessInstance processInstance = request.getProcessInstances().get(0);
+        assertNotNull(processInstance.getAssignes());
+        assertEquals("u1", processInstance.getAssignes().get(0).getUuid());
+    }
+
+    @Test
+    void serializationStillEmitsAssignesForPersisterJsonPaths() throws Exception {
+        ProcessInstance processInstance = new ProcessInstance();
+        User user = new User();
+        user.setUuid("u1");
+        processInstance.setAssignes(Collections.singletonList(user));
+
+        String json = springBootLikeMapper().writeValueAsString(processInstance);
+
+        // The persister yml extracts ProcessInstances.*.assignes.* — the
+        // serialized key must remain "assignes" for existing consumers.
+        assertTrue(json.contains("\"assignes\""));
+        assertFalse(json.contains("\"assignees\""));
+    }
+}


### PR DESCRIPTION
Persists assignees on self-loop `ASSIGN` transitions in egov-workflow-v2 (previously a self-loop ASSIGN could drop the assignee list). Adds `ProcessInstance` handling + tests.

- **Source:** `ChakshuGautam/Digit-Core@43f925c2` (`fix(workflow-v2): persist assignees on self-loop ASSIGN transitions`)
- Cherry-picked onto `2.12` (1 commit). The sibling `workflow-dynamic-state-tenant` fork commit is **already present in 2.12** and is intentionally not included here.
- **Deployment:** sits above the `maven-jdk21-983e8b2` build that bomet currently runs, so not yet live on bomet — upstreaming it here makes it available for the next build.
