### PR TITLE
[2.12] egov-user: prevent NPE in _updatenovalidate / profile _update

### DIFF
--- a/core-services/egov-user/src/main/java/org/egov/user/domain/service/UserService.java
+++ b/core-services/egov-user/src/main/java/org/egov/user/domain/service/UserService.java
@@ -383,7 +383,10 @@ public class UserService {
         user.setPassword(encryptPwd(user.getPassword()));
         /* encrypt */
         user = encryptionDecryptionUtil.encryptObject(user, "User", User.class);
-        userRepository.update(user, existingUser,requestInfo.getUserInfo().getId(), requestInfo.getUserInfo().getUuid() );
+        long loggedInUserId = requestInfo.getUserInfo() != null && requestInfo.getUserInfo().getId() != null
+                ? requestInfo.getUserInfo().getId() : 0L;
+        String loggedInUserUuid = requestInfo.getUserInfo() != null ? requestInfo.getUserInfo().getUuid() : null;
+        userRepository.update(user, existingUser, loggedInUserId, loggedInUserUuid);
 
         // If user is being unlocked via update, reset failed login attempts
         if (user.getAccountLocked() != null && !user.getAccountLocked() && existingUser.getAccountLocked())
@@ -440,7 +443,10 @@ public class UserService {
         validateProfileUpdateIsDoneByTheSameLoggedInUser(user);
         user.nullifySensitiveFields();
         validatePassword(user.getPassword());
-        userRepository.update(user, existingUser,requestInfo.getUserInfo().getId(), requestInfo.getUserInfo().getUuid() );
+        long partialLoggedInUserId = requestInfo.getUserInfo() != null && requestInfo.getUserInfo().getId() != null
+                ? requestInfo.getUserInfo().getId() : 0L;
+        String partialLoggedInUserUuid = requestInfo.getUserInfo() != null ? requestInfo.getUserInfo().getUuid() : null;
+        userRepository.update(user, existingUser, partialLoggedInUserId, partialLoggedInUserUuid);
         User updatedUser = getUserByUuid(user.getUuid());
         
         /* decrypt here */


### PR DESCRIPTION
Prevents an NPE in egov-user `_updatenovalidate` and profile `_update` paths.

- **Source:** `ChakshuGautam/Digit-Core@ccc0e133` (`fix(egov-user): prevent NPE in _updatenovalidate and profile _update`)
- Cherry-picked onto `2.12` (1 commit; the unrelated localization commit on the same fork branch is excluded).
- **Deployment note:** bomet runs a separate **JDK8** egov-user build (`egov-user:mobilevalidation-jdk8-4984479`, the mobile-validation fork line whose feature is already in 2.12 via #967). This NPE fix comes from the JDK21 fork lineage; its presence in the deployed JDK8 build is unverified. This PR upstreams the fix into 2.12 regardless.
