### PR TITLE
[2.12] egov-user: tenant-aware encryption + localization overloads

### DIFF
--- a/core-services/egov-user/src/main/java/org/egov/user/domain/service/UserService.java
+++ b/core-services/egov-user/src/main/java/org/egov/user/domain/service/UserService.java
@@ -161,7 +161,7 @@ public class UserService {
 
         /* encrypt here */
 
-        userSearchCriteria = encryptionDecryptionUtil.encryptObject(userSearchCriteria, "User", UserSearchCriteria.class);
+        userSearchCriteria = encryptionDecryptionUtil.encryptObject(userSearchCriteria, "User", UserSearchCriteria.class, userSearchCriteria.getTenantId());
         List<User> users = userRepository.findAll(userSearchCriteria);
 
         if (users.isEmpty())
@@ -218,7 +218,7 @@ public class UserService {
         	altmobnumber = searchCriteria.getMobileNumber();
         }
 
-        searchCriteria = encryptionDecryptionUtil.encryptObject(searchCriteria, "User", UserSearchCriteria.class);
+        searchCriteria = encryptionDecryptionUtil.encryptObject(searchCriteria, "User", UserSearchCriteria.class, searchCriteria.getTenantId());
         
         if(altmobnumber!=null) {
         	searchCriteria.setAlternatemobilenumber(altmobnumber);
@@ -246,7 +246,7 @@ public class UserService {
         user.validateNewUser(createUserValidateName);
         conditionallyValidateOtp(user);
         /* encrypt here */
-        user = encryptionDecryptionUtil.encryptObject(user, "User", User.class);
+        user = encryptionDecryptionUtil.encryptObject(user, "User", User.class, user.getTenantId());
         validateUserUniqueness(user);
         if (isEmpty(user.getPassword())) {
             user.setPassword(UUID.randomUUID().toString());
@@ -382,7 +382,7 @@ public class UserService {
         validatePassword(user.getPassword());
         user.setPassword(encryptPwd(user.getPassword()));
         /* encrypt */
-        user = encryptionDecryptionUtil.encryptObject(user, "User", User.class);
+        user = encryptionDecryptionUtil.encryptObject(user, "User", User.class, user.getTenantId());
         userRepository.update(user, existingUser,requestInfo.getUserInfo().getId(), requestInfo.getUserInfo().getUuid() );
 
         // If user is being unlocked via update, reset failed login attempts
@@ -434,7 +434,7 @@ public class UserService {
     public User partialUpdate(User user, RequestInfo requestInfo) {
         mobileNumberValidator.validateAndSetMobileNumbers(user, requestInfo);
         /* encrypt here */
-        user = encryptionDecryptionUtil.encryptObject(user, "User", User.class);
+        user = encryptionDecryptionUtil.encryptObject(user, "User", User.class, user.getTenantId());
 
         User existingUser = getUserByUuid(user.getUuid());
         validateProfileUpdateIsDoneByTheSameLoggedInUser(user);
@@ -508,7 +508,7 @@ public class UserService {
         user.updatePassword(encryptPwd(request.getNewPassword()));
         /* encrypt here */
         /* encrypted value is stored in DB*/
-        user = encryptionDecryptionUtil.encryptObject(user, "User", User.class);
+        user = encryptionDecryptionUtil.encryptObject(user, "User", User.class, user.getTenantId());
         userRepository.update(user, user,user.getId() , user.getUuid());
     }
 

--- a/core-services/egov-user/src/main/java/org/egov/user/domain/service/utils/EncryptionDecryptionUtil.java
+++ b/core-services/egov-user/src/main/java/org/egov/user/domain/service/utils/EncryptionDecryptionUtil.java
@@ -8,6 +8,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.egov.common.contract.request.RequestInfo;
 import org.egov.common.contract.request.Role;
 import org.egov.common.contract.request.User;
+import org.egov.common.utils.MultiStateInstanceUtil;
 import org.egov.encryption.EncryptionService;
 import org.egov.encryption.audit.AuditService;
 import org.egov.tracer.model.CustomException;
@@ -32,6 +33,9 @@ public class EncryptionDecryptionUtil {
     @Autowired
     private ObjectMapper objectMapper;
 
+    @Autowired
+    private MultiStateInstanceUtil centralInstanceUtil;
+
     @Value(("${state.level.tenant.id}"))
     private String stateLevelTenantId;
 
@@ -48,6 +52,34 @@ public class EncryptionDecryptionUtil {
                 return null;
             }
             T encryptedObject = encryptionService.encryptJson(objectToEncrypt, key, stateLevelTenantId, classType);
+            if (encryptedObject == null) {
+                throw new CustomException("ENCRYPTION_NULL_ERROR", "Null object found on performing encryption");
+            }
+            return encryptedObject;
+        } catch (IOException | HttpClientErrorException | HttpServerErrorException | ResourceAccessException e) {
+            log.error("Error occurred while encrypting", e);
+            throw new CustomException("ENCRYPTION_ERROR", "Error occurred in encryption process");
+        } catch (Exception e) {
+            log.error("Unknown Error occurred while encrypting", e);
+            throw new CustomException("UNKNOWN_ERROR", "Unknown error occurred in encryption process");
+        }
+    }
+
+    /**
+     * Tenant-aware encryption: derives the state-level tenant dynamically from the
+     * provided tenantId instead of using the hardcoded configuration property.
+     * This enables encryption to work correctly for any state root, not just the
+     * configured default.
+     */
+    public <T> T encryptObject(Object objectToEncrypt, String key, Class<T> classType, String tenantId) {
+        try {
+            if (objectToEncrypt == null) {
+                return null;
+            }
+            String resolvedTenantId = (tenantId != null)
+                    ? centralInstanceUtil.getStateLevelTenant(tenantId)
+                    : stateLevelTenantId;
+            T encryptedObject = encryptionService.encryptJson(objectToEncrypt, key, resolvedTenantId, classType);
             if (encryptedObject == null) {
                 throw new CustomException("ENCRYPTION_NULL_ERROR", "Null object found on performing encryption");
             }

--- a/core-services/egov-user/src/main/java/org/egov/user/domain/service/utils/LocalizationUtil.java
+++ b/core-services/egov-user/src/main/java/org/egov/user/domain/service/utils/LocalizationUtil.java
@@ -3,6 +3,7 @@ package org.egov.user.domain.service.utils;
 import com.jayway.jsonpath.JsonPath;
 import lombok.extern.slf4j.Slf4j;
 import org.egov.common.contract.request.RequestInfo;
+import org.egov.common.utils.MultiStateInstanceUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -33,6 +34,8 @@ public class LocalizationUtil {
     private String defaultLocale;
     @Autowired
     private RestTemplate restTemplate;
+    @Autowired
+    private MultiStateInstanceUtil centralInstanceUtil;
 
     public String getLocalizedMessage(String code, String locale, RequestInfo requestInfo) {
         if(locale == null)
@@ -52,6 +55,29 @@ public class LocalizationUtil {
 
     String getUri(String locale) {
         return localizationServiceHost + localizationServiceSearchPath + "?locale=" + locale + "&tenantId=" + tenantId + "&module=" + module;
+    }
+
+    /**
+     * Tenant-aware localization: derives the state-level tenant dynamically from the
+     * provided tenantId instead of using the hardcoded configuration property.
+     */
+    public String getLocalizedMessage(String code, String locale, RequestInfo requestInfo, String userTenantId) {
+        if(locale == null)
+            locale = defaultLocale;
+        String resolvedTenantId = (userTenantId != null)
+                ? centralInstanceUtil.getStateLevelTenant(userTenantId)
+                : tenantId;
+        String uri = localizationServiceHost + localizationServiceSearchPath + "?locale=" + locale + "&tenantId=" + resolvedTenantId + "&module=" + module;
+        Object responseobj = restTemplate.postForObject(uri, requestInfo, Map.class);
+        Object object = JsonPath.read(responseobj,
+                "$.messages[?(@.code==\"" + code + "\")].message");
+        List<String> messages = (ArrayList<String>) object;
+        if(CollectionUtils.isEmpty(messages)){
+            log.warn("No localization messages returned for locale: " + locale +" . Continuing with english language");
+            messages.add(DEFAULT_EMAIL_UPDATION_MESSAGE);
+        }
+        String message = messages.get(0);
+        return message;
     }
 
 }


### PR DESCRIPTION
Makes egov-user encryption/localization **tenant-aware**: adds tenant-scoped overloads and migrates all call sites to pass the request tenant, so encryption/decryption resolves the correct per-tenant key instead of a hardcoded state-level tenant.

- **Source:** `ChakshuGautam/Digit-Core@c6f5438` + `@884c5e6` (tenant-aware overloads + migrate all call sites)
- Cherry-picked onto `2.12` (2 commits).
- **Deployment note:** same JDK8 caveat as #1383 — bomet's deployed egov-user is the JDK8 mobile-validation build; presence there is unverified. This PR upstreams the fix into 2.12.
