### PR TITLE
Hcmpre 2023 corrfix tenant

### DIFF
--- a/core-services/gateway/CHANGELOG.MD
+++ b/core-services/gateway/CHANGELOG.MD
@@ -1,5 +1,19 @@
 # Changelog
 All notable changes to this module will be documented in this file.
 
+## 1.0.4 - 2026-05-04
+- Handled GET & form content type separately in all necessary filters
+
+## 1.0.3 - 2026-03-16
+- Upgraded Spring Boot version from 3.2.2 to 3.4.5 to fix HIGH/CRITICAL CVEs
+- Upgraded tracer, services-common library versions
+- Upgraded spring-cloud-starter-gateway from 4.1.1 to 4.1.5
+- Removed hardcoded log4j2.version override (now managed by Spring Boot)
+
+## 2.9.1 - 2025-05-21
+- Upgraded tracer version from 2.9.0 to 2.9.1
+- added variables in application.properties required for opentelemetry
+
 ## 2.9.1-HOTFIX - 2024-05-28
 - Fixed support for form data
+

--- a/core-services/gateway/CHANGELOG.MD
+++ b/core-services/gateway/CHANGELOG.MD
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this module will be documented in this file.
 
+## 1.0.5 - 2026-07-17
+- Forwarded the resolved tenantId (and correlationId) to downstream services by rebuilding the exchange in RequestEnrichmentFilter — a bare request mutate was silently discarded by Spring Cloud Gateway
+- Resolved tenantId for tracing from the query param or request body, so it propagates on non-central-instance environments
+- Added feature flag `egov.gateway.tenant.propagation.enabled` (default true) to toggle tenantId forwarding
+
 ## 1.0.4 - 2026-05-04
 - Handled GET & form content type separately in all necessary filters
 

--- a/core-services/gateway/pom.xml
+++ b/core-services/gateway/pom.xml
@@ -1,25 +1,55 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.2</version>
+		<version>3.4.5</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.egov</groupId>
 	<artifactId>gateway</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.0.4-SNAPSHOT</version>
 	<name>gateway</name>
 	<description>API Gateway for Spring Boot</description>
 	<properties>
 		<java.version>17</java.version>
 		<kafka.version>3.1.1</kafka.version>
-		<log4j2.version>2.17.1</log4j2.version>
+		<spring-cloud.version>2024.0.1</spring-cloud.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
+		<tomcat.version>10.1.45</tomcat.version>
+		<jackson-bom.version>2.18.6</jackson-bom.version>
+		<spring-framework.version>6.2.11</spring-framework.version>
+		<postgresql.version>42.7.7</postgresql.version>
+		<netty.version>4.1.124.Final</netty.version>
 	</properties>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-dependencies</artifactId>
+				<version>${spring-cloud.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>io.opentelemetry</groupId>
+				<artifactId>opentelemetry-bom</artifactId>
+				<version>1.35.0</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>io.opentelemetry.instrumentation</groupId>
+				<artifactId>opentelemetry-instrumentation-bom-alpha</artifactId>
+				<version>2.1.0-alpha</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -33,18 +63,16 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-gateway</artifactId>
-			<version>4.1.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.jayway.jsonpath</groupId>
 			<artifactId>json-path</artifactId>
-			<version>2.9.0</version>
 		</dependency>
-<!--		<dependency>-->
-<!--			<groupId>org.springframework.cloud</groupId>-->
-<!--			<artifactId>spring-cloud-dependencies</artifactId>-->
-<!--			<version>2023.0.0</version>-->
-<!--		</dependency>-->
+		<!--		<dependency>-->
+		<!--			<groupId>org.springframework.cloud</groupId>-->
+		<!--			<artifactId>spring-cloud-dependencies</artifactId>-->
+		<!--			<version>2023.0.0</version>-->
+		<!--		</dependency>-->
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
@@ -53,26 +81,27 @@
 		<dependency>
 			<groupId>org.egov.services</groupId>
 			<artifactId>tracer</artifactId>
-			<version>2.9.0-SNAPSHOT</version>
+			<version>2.9.2-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.egov.services</groupId>
 			<artifactId>services-common</artifactId>
-			<version>2.9.0-SNAPSHOT</version>
+			<version>2.9.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.kafka</groupId>
 			<artifactId>spring-kafka</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>4.5.14</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
 			<version>2.10.1</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.kafka</groupId>
-			<artifactId>spring-kafka</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -98,21 +127,21 @@
 		</plugins>
 	</build>
 	<repositories>
-<!--		<repository>-->
-<!--			<id>repo.egovernments.org</id>-->
-<!--			<name>eGov ERP Releases Repository</name>-->
-<!--			<url>https://nexus-repo.egovernments.org/nexus/content/repositories/releases/</url>-->
-<!--		</repository>-->
-<!--		<repository>-->
-<!--			<id>repo.egovernments.org.snapshots</id>-->
-<!--			<name>eGov ERP Releases Repository</name>-->
-<!--			<url>https://nexus-repo.egovernments.org/nexus/content/repositories/snapshots/</url>-->
-<!--		</repository>-->
-<!--		<repository>-->
-<!--			<id>repo.egovernments.org.public</id>-->
-<!--			<name>eGov Public Repository Group</name>-->
-<!--			<url>https://nexus-repo.egovernments.org/nexus/content/groups/public/</url>-->
-<!--		</repository>-->
+		<!--		<repository>-->
+		<!--			<id>repo.egovernments.org</id>-->
+		<!--			<name>eGov ERP Releases Repository</name>-->
+		<!--			<url>https://nexus-repo.egovernments.org/nexus/content/repositories/releases/</url>-->
+		<!--		</repository>-->
+		<!--		<repository>-->
+		<!--			<id>repo.egovernments.org.snapshots</id>-->
+		<!--			<name>eGov ERP Releases Repository</name>-->
+		<!--			<url>https://nexus-repo.egovernments.org/nexus/content/repositories/snapshots/</url>-->
+		<!--		</repository>-->
+		<!--		<repository>-->
+		<!--			<id>repo.egovernments.org.public</id>-->
+		<!--			<name>eGov Public Repository Group</name>-->
+		<!--			<url>https://nexus-repo.egovernments.org/nexus/content/groups/public/</url>-->
+		<!--		</repository>-->
 		<repository>
 			<id>repo.digit.org</id>
 			<name>eGov DIGIT Releases Repository</name>

--- a/core-services/gateway/pom.xml
+++ b/core-services/gateway/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.egov</groupId>
 	<artifactId>gateway</artifactId>
-	<version>1.0.4-SNAPSHOT</version>
+	<version>1.0.5-SNAPSHOT</version>
 	<name>gateway</name>
 	<description>API Gateway for Spring Boot</description>
 	<properties>

--- a/core-services/gateway/pom.xml
+++ b/core-services/gateway/pom.xml
@@ -117,6 +117,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-reactor-netty</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/core-services/gateway/src/main/java/com/example/gateway/config/ApplicationProperties.java
+++ b/core-services/gateway/src/main/java/com/example/gateway/config/ApplicationProperties.java
@@ -33,6 +33,10 @@ public class ApplicationProperties {
     @Value("${egov.authorize.access.control.host}${egov.authorize.access.control.uri}")
     private String authorizationUrl;
 
+    // Propagate tenantId (MDC + downstream header) for tracing even on non-central-instance envs. Kill-switch.
+    @Value("${egov.gateway.tenant.propagation.enabled:true}")
+    private boolean tenantPropagationEnabled;
+
     private List<String> encryptedUrlSet;
 
     private List<String> openEndpointsWhitelist;

--- a/core-services/gateway/src/main/java/com/example/gateway/filters/pre/RbacFilter.java
+++ b/core-services/gateway/src/main/java/com/example/gateway/filters/pre/RbacFilter.java
@@ -126,7 +126,7 @@ public class RbacFilter implements GlobalFilter, Ordered {
 
         headers.add(CORRELATION_ID_HEADER_NAME, (String) exchange.getAttributes().get(CORRELATION_ID_KEY));
 
-        if (centralInstanceUtil.getIsEnvironmentCentralInstance())
+        if (!StringUtils.isEmpty(exchange.getAttributes().get(TENANTID_MDC)))
             headers.add(REQUEST_TENANT_ID_KEY, (String) exchange.getAttributes().get(TENANTID_MDC));
 
         final HttpEntity<Object> httpEntity = new HttpEntity<>(authorizationRequestWrapper, headers);

--- a/core-services/gateway/src/main/java/com/example/gateway/filters/pre/RequestEnrichmentFilter.java
+++ b/core-services/gateway/src/main/java/com/example/gateway/filters/pre/RequestEnrichmentFilter.java
@@ -1,5 +1,6 @@
 package com.example.gateway.filters.pre;
 
+import com.example.gateway.config.ApplicationProperties;
 import com.example.gateway.filters.pre.helpers.RequestEnrichmentFilterHelper;
 import com.example.gateway.utils.CommonUtils;
 import lombok.extern.slf4j.Slf4j;
@@ -28,32 +29,48 @@ public class RequestEnrichmentFilter implements GlobalFilter, Ordered {
 
     private CommonUtils commonUtils;
 
-    public RequestEnrichmentFilter(ModifyRequestBodyGatewayFilterFactory modifyRequestBodyFilter, RequestEnrichmentFilterHelper requestEnrichmentFilterHelper, CommonUtils commonUtils) {
+    private ApplicationProperties applicationProperties;
+
+    public RequestEnrichmentFilter(ModifyRequestBodyGatewayFilterFactory modifyRequestBodyFilter, RequestEnrichmentFilterHelper requestEnrichmentFilterHelper, CommonUtils commonUtils, ApplicationProperties applicationProperties) {
         this.modifyRequestBodyFilter = modifyRequestBodyFilter;
         this.requestEnrichmentFilterHelper = requestEnrichmentFilterHelper;
         this.commonUtils = commonUtils;
+        this.applicationProperties = applicationProperties;
     }
 
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
         String contentType = exchange.getRequest().getHeaders().getFirst(HttpHeaders.CONTENT_TYPE);
         boolean isGetRequest = HttpMethod.GET.equals(exchange.getRequest().getMethod());
+        // rebuild the request with the tracing headers so they actually reach downstream (a bare
+        // getRequest().mutate() inside the body-rewrite is discarded by ModifyRequestBody)
+        ServerWebExchange enriched = withTracingHeaders(exchange);
         if (isGetRequest || commonUtils.isFormContentType(contentType)) {
-            // GET/form requests skip body-rewrite; still forward correlationId + tenantId headers so
-            // they propagate to the downstream service's logs.
-            String correlationId = (String) exchange.getAttributes().get(CORRELATION_ID_KEY);
-            String tenantId = (String) exchange.getAttributes().get(TENANTID_MDC);
-            exchange.getRequest().mutate().headers(httpHeaders -> {
-                if (!ObjectUtils.isEmpty(correlationId))
-                    httpHeaders.add(CORRELATION_ID_HEADER_NAME, correlationId);
-                if (!ObjectUtils.isEmpty(tenantId))
-                    httpHeaders.add(REQUEST_TENANT_ID_KEY, tenantId);
-            });
-            return chain.filter(exchange);
+            return chain.filter(enriched);
         } else {
-            return modifyRequestBodyFilter.apply(new ModifyRequestBodyGatewayFilterFactory.Config().setRewriteFunction(Map.class, Map.class, requestEnrichmentFilterHelper)).filter(exchange, chain);
+            return modifyRequestBodyFilter.apply(new ModifyRequestBodyGatewayFilterFactory.Config().setRewriteFunction(Map.class, Map.class, requestEnrichmentFilterHelper)).filter(enriched, chain);
         }
 
+    }
+
+    // add correlationId (if absent) + resolved tenantId as downstream headers via a request rebuild
+    private ServerWebExchange withTracingHeaders(ServerWebExchange exchange) {
+        String correlationId = (String) exchange.getAttributes().get(CORRELATION_ID_KEY);
+        String tenant = null;
+        if (applicationProperties.isTenantPropagationEnabled()) {
+            tenant = (String) exchange.getAttributes().get(TENANTID_MDC);
+            if (ObjectUtils.isEmpty(tenant))
+                tenant = exchange.getRequest().getQueryParams().getFirst(REQUEST_TENANT_ID_KEY); // ?tenantId= fallback
+        }
+        final String corr = correlationId, tenantId = tenant;
+        if (ObjectUtils.isEmpty(corr) && ObjectUtils.isEmpty(tenantId))
+            return exchange;
+        return exchange.mutate().request(exchange.getRequest().mutate().headers(httpHeaders -> {
+            if (!ObjectUtils.isEmpty(corr) && !httpHeaders.containsKey(CORRELATION_ID_HEADER_NAME))
+                httpHeaders.add(CORRELATION_ID_HEADER_NAME, corr);
+            if (!ObjectUtils.isEmpty(tenantId))
+                httpHeaders.set(REQUEST_TENANT_ID_KEY, tenantId);
+        }).build()).build();
     }
 
     @Override

--- a/core-services/gateway/src/main/java/com/example/gateway/filters/pre/RequestEnrichmentFilter.java
+++ b/core-services/gateway/src/main/java/com/example/gateway/filters/pre/RequestEnrichmentFilter.java
@@ -10,10 +10,13 @@ import org.springframework.cloud.gateway.filter.factory.rewrite.ModifyRequestBod
 import org.springframework.core.Ordered;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
 import java.util.Map;
+
+import static com.example.gateway.constants.GatewayConstants.*;
 
 @Slf4j
 @Component
@@ -36,7 +39,16 @@ public class RequestEnrichmentFilter implements GlobalFilter, Ordered {
         String contentType = exchange.getRequest().getHeaders().getFirst(HttpHeaders.CONTENT_TYPE);
         boolean isGetRequest = HttpMethod.GET.equals(exchange.getRequest().getMethod());
         if (isGetRequest || commonUtils.isFormContentType(contentType)) {
-            // TODO: Refactor the helper class to be re-usable for this case as well.
+            // GET/form requests skip body-rewrite; still forward correlationId + tenantId headers so
+            // they propagate to the downstream service's logs.
+            String correlationId = (String) exchange.getAttributes().get(CORRELATION_ID_KEY);
+            String tenantId = (String) exchange.getAttributes().get(TENANTID_MDC);
+            exchange.getRequest().mutate().headers(httpHeaders -> {
+                if (!ObjectUtils.isEmpty(correlationId))
+                    httpHeaders.add(CORRELATION_ID_HEADER_NAME, correlationId);
+                if (!ObjectUtils.isEmpty(tenantId))
+                    httpHeaders.add(REQUEST_TENANT_ID_KEY, tenantId);
+            });
             return chain.filter(exchange);
         } else {
             return modifyRequestBodyFilter.apply(new ModifyRequestBodyGatewayFilterFactory.Config().setRewriteFunction(Map.class, Map.class, requestEnrichmentFilterHelper)).filter(exchange, chain);

--- a/core-services/gateway/src/main/java/com/example/gateway/filters/pre/helpers/CorrIdFormDataFilterHelper.java
+++ b/core-services/gateway/src/main/java/com/example/gateway/filters/pre/helpers/CorrIdFormDataFilterHelper.java
@@ -70,6 +70,10 @@ public class CorrIdFormDataFilterHelper implements RewriteFunction<MultiValueMap
 
         }
 
+        // propagate tenantId for tracing on non-central-instance envs too (best-effort, never throws)
+        if (applicationProperties.isTenantPropagationEnabled())
+            commonUtils.resolveTenantForTracing(exchange, body == null ? null : body.toSingleValueMap());
+
         String correlationId = UUID.randomUUID().toString();
         MDC.put(CORRELATION_ID_KEY, correlationId);
         exchange.getAttributes().put(CORRELATION_ID_KEY, correlationId);

--- a/core-services/gateway/src/main/java/com/example/gateway/filters/pre/helpers/CorrelationIdFilterHelper.java
+++ b/core-services/gateway/src/main/java/com/example/gateway/filters/pre/helpers/CorrelationIdFilterHelper.java
@@ -39,6 +39,9 @@ public class CorrelationIdFilterHelper implements RewriteFunction<Map, Map> {
 
         // enriches tenantIds in MDC
         commonUtils.handleCentralInstanceLogic(exchange, requestURI, isOpenRequest, isMixModeRequest, body);
+        // propagate tenantId for tracing on non-central-instance envs too (best-effort, never throws)
+        if (applicationProperties.isTenantPropagationEnabled())
+            commonUtils.resolveTenantForTracing(exchange, body);
         String correlationId = UUID.randomUUID().toString();
         MDC.put(CORRELATION_ID_KEY, correlationId);
         exchange.getAttributes().put(CORRELATION_ID_KEY, correlationId);

--- a/core-services/gateway/src/main/java/com/example/gateway/filters/pre/helpers/RbacFilterHelper.java
+++ b/core-services/gateway/src/main/java/com/example/gateway/filters/pre/helpers/RbacFilterHelper.java
@@ -100,7 +100,7 @@ public class RbacFilterHelper implements RewriteFunction<Map, Map> {
 
         headers.add(CORRELATION_ID_HEADER_NAME, (String) exchange.getAttributes().get(CORRELATION_ID_KEY));
 
-        if (centralInstanceUtil.getIsEnvironmentCentralInstance())
+        if (!StringUtils.isEmpty(exchange.getAttributes().get(TENANTID_MDC)))
             headers.add(REQUEST_TENANT_ID_KEY, (String) exchange.getAttributes().get(TENANTID_MDC));
 
         final HttpEntity<Object> httpEntity = new HttpEntity<>(authorizationRequestWrapper, headers);

--- a/core-services/gateway/src/main/java/com/example/gateway/filters/pre/helpers/RequestEnrichmentFilterHelper.java
+++ b/core-services/gateway/src/main/java/com/example/gateway/filters/pre/helpers/RequestEnrichmentFilterHelper.java
@@ -1,5 +1,6 @@
 package com.example.gateway.filters.pre.helpers;
 
+import com.example.gateway.config.ApplicationProperties;
 import com.example.gateway.utils.CommonUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -34,6 +35,8 @@ public class RequestEnrichmentFilterHelper implements RewriteFunction<Map, Map> 
     private MultiStateInstanceUtil centralInstanceUtil;
 
     private CommonUtils commonUtils;
+
+    private ApplicationProperties applicationProperties;
     private static final String FAILED_TO_ENRICH_REQUEST_BODY_MESSAGE = "Failed to enrich request body";
     private static final String USER_SERIALIZATION_MESSAGE = "Failed to serialize user";
     private static final String SKIPPED_BODY_ENRICHMENT_DUE_TO_NO_KNOWN_FIELD_MESSAGE = "Skipped enriching request body since request info field is not present.";
@@ -47,10 +50,11 @@ public class RequestEnrichmentFilterHelper implements RewriteFunction<Map, Map> 
     private static final String PASS_THROUGH_GATEWAY_HEADER_VALUE = "true";
     private Logger logger = LoggerFactory.getLogger(this.getClass());
 
-    public RequestEnrichmentFilterHelper(MultiStateInstanceUtil centralInstanceUtil, CommonUtils commonUtils, ObjectMapper objectMapper) {
+    public RequestEnrichmentFilterHelper(MultiStateInstanceUtil centralInstanceUtil, CommonUtils commonUtils, ObjectMapper objectMapper, ApplicationProperties applicationProperties) {
         this.centralInstanceUtil = centralInstanceUtil;
         this.commonUtils = commonUtils;
         this.objectMapper = objectMapper;
+        this.applicationProperties = applicationProperties;
     }
 
     @Override
@@ -58,6 +62,10 @@ public class RequestEnrichmentFilterHelper implements RewriteFunction<Map, Map> 
 
         // Enrich User Info and Correlation Id in the request
         modifyRequestBody(exchange, body);
+
+        // re-resolve tenantId here so it lands on the forwarding exchange; idempotent, never throws
+        if (applicationProperties.isTenantPropagationEnabled())
+            commonUtils.resolveTenantForTracing(exchange, body);
 
         // Add User_Info and Correlation Id in the header
         addRequestHeaders(exchange, body);

--- a/core-services/gateway/src/main/java/com/example/gateway/filters/pre/helpers/RequestEnrichmentFilterHelper.java
+++ b/core-services/gateway/src/main/java/com/example/gateway/filters/pre/helpers/RequestEnrichmentFilterHelper.java
@@ -79,7 +79,7 @@ public class RequestEnrichmentFilterHelper implements RewriteFunction<Map, Map> 
 
         exchange.getRequest().mutate().headers(httpHeaders -> {
             httpHeaders.add(CORRELATION_ID_HEADER_NAME, correlationId);
-            if (centralInstanceUtil.getIsEnvironmentCentralInstance()) {
+            if (!ObjectUtils.isEmpty(TenantId)) {
                 httpHeaders.add(REQUEST_TENANT_ID_KEY, TenantId);
             }
         });

--- a/core-services/gateway/src/main/java/com/example/gateway/utils/CommonUtils.java
+++ b/core-services/gateway/src/main/java/com/example/gateway/utils/CommonUtils.java
@@ -80,6 +80,38 @@ public class CommonUtils {
         }
     }
 
+    /**
+     * Puts the resolved tenantId into MDC and the exchange
+     * attribute so it appears in gateway and downstream logs even on non-central-instance environments
+     * No-op if a tenantId is already resolved for this exchange.
+     */
+    public void resolveTenantForTracing(ServerWebExchange exchange, Map body) {
+        if (!ObjectUtils.isEmpty(exchange.getAttributes().get(TENANTID_MDC)))
+            return;
+        try {
+            Set<String> tenantIds = new HashSet<>();
+            if (HttpMethod.GET.equals(exchange.getRequest().getMethod()) || ObjectUtils.isEmpty(body)) {
+                MultiValueMap<String, String> queryParams = exchange.getRequest().getQueryParams();
+                if (!CollectionUtils.isEmpty(queryParams) && !CollectionUtils.isEmpty(queryParams.get(REQUEST_TENANT_ID_KEY))) {
+                    String tenantId = queryParams.getFirst(REQUEST_TENANT_ID_KEY);
+                    if (tenantId != null && tenantId.contains(","))
+                        tenantIds.addAll(Arrays.asList(tenantId.split(",")));
+                    else if (tenantId != null)
+                        tenantIds.add(tenantId);
+                }
+            } else {
+                tenantIds = getTenantIdsFromRequest(exchange.getRequest(), body);
+            }
+            String tenantId = getLowLevelTenantIdFromSet(tenantIds);
+            if (!ObjectUtils.isEmpty(tenantId)) {
+                MDC.put(TENANTID_MDC, tenantId);
+                exchange.getAttributes().put(TENANTID_MDC, tenantId);
+            }
+        } catch (Exception ex) {
+            log.debug("resolveTenantForTracing: could not resolve tenantId (ignored): {}", ex.getMessage());
+        }
+    }
+
     private static String getRequestMethod(ServerHttpRequest serverHttpRequest) {
         return serverHttpRequest.getMethod().toString();
     }

--- a/core-services/gateway/src/main/java/com/example/gateway/utils/UserUtils.java
+++ b/core-services/gateway/src/main/java/com/example/gateway/utils/UserUtils.java
@@ -52,7 +52,7 @@ public class UserUtils {
         String authURL = String.format("%s%s%s", applicationProperties.getAuthServiceHost(), applicationProperties.getAuthUri(), authToken);
         final HttpHeaders headers = new HttpHeaders();
         headers.add(CORRELATION_ID_HEADER_NAME, (String) exchange.getAttributes().get(CORRELATION_ID_KEY));
-        if (multiStateInstanceUtil.getIsEnvironmentCentralInstance())
+        if (exchange.getAttributes().get(TENANTID_MDC) != null)
             headers.add(REQUEST_TENANT_ID_KEY, (String) exchange.getAttributes().get(TENANTID_MDC));
         final HttpEntity<Object> httpEntity = new HttpEntity<>(null, headers);
 
@@ -77,7 +77,7 @@ public class UserUtils {
 
         final HttpHeaders headers = new HttpHeaders();
         headers.add(CORRELATION_ID_HEADER_NAME, correlationId);
-        if (multiStateInstanceUtil.getIsEnvironmentCentralInstance())
+        if (tenantId != null && !tenantId.isEmpty())
             headers.add(REQUEST_TENANT_ID_KEY, tenantId);
         final HttpEntity<Object> httpEntity = new HttpEntity<>(userSearchRequest, headers);
 

--- a/core-services/gateway/src/main/resources/application.properties
+++ b/core-services/gateway/src/main/resources/application.properties
@@ -35,6 +35,9 @@ state.level.tenantid.length=2
 state.schema.index.position.tenantid=1
 is.environment.central.instance=true
 
+# forward tenantId (MDC + downstream header) for tracing even on non-central-instance envs; kill-switch
+egov.gateway.tenant.propagation.enabled=true
+
 logging.pattern.console=%clr(%X{CORRELATION_ID:-}) %clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}
 
 egov.encrypted-endpoints-list=/user/oauth/token,/filestore/v1/files

--- a/core-services/gateway/src/test/java/com/example/gateway/filters/pre/AuthPreCheckFilterGetHeaderAuthTest.java
+++ b/core-services/gateway/src/test/java/com/example/gateway/filters/pre/AuthPreCheckFilterGetHeaderAuthTest.java
@@ -1,0 +1,45 @@
+package com.example.gateway.filters.pre;
+
+import com.example.gateway.config.ApplicationProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.util.Collections;
+
+import static com.example.gateway.constants.GatewayConstants.AUTH_BOOLEAN_FLAG_NAME;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Anti-regression: a secured GET carrying the auth token in the "auth-token" HEADER must authenticate
+ * (AUTH flag TRUE) via handleAuthPreCheck — NOT return 401. The master-lineage gateway (image 9feff20)
+ * had dropped this GET header-auth path and 401'd such requests (e.g. DIGIT Studio
+ * GET /public-service-init/v1/service?tenantId=dev). This base (gateway-2.9.2-base-docker-upgrade)
+ * keeps it, and the tenant-propagation changes leave AuthPreCheckFilter untouched.
+ */
+class AuthPreCheckFilterGetHeaderAuthTest {
+
+    private ApplicationProperties props() {
+        ApplicationProperties p = new ApplicationProperties();
+        p.setOpenEndpointsWhitelistValues(Collections.emptyList());
+        p.setMixModeEndpointListValues(Collections.emptyList());
+        return p;
+    }
+
+    @Test
+    void securedGet_withAuthTokenHeader_authenticates_not401() {
+        // token-present path uses only the flag + chain; other deps are unused here
+        AuthPreCheckFilter filter = new AuthPreCheckFilter(null, null, props(), null, null, null);
+        MockServerWebExchange exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.get("/public-service-init/v1/service?tenantId=dev")
+                        .header("auth-token", "valid-session-token").build());
+        GatewayFilterChain chain = ex -> Mono.empty();
+
+        // must not throw the 401 CustomException, and must mark the request as authenticated
+        assertDoesNotThrow(() -> filter.handleAuthPreCheck(exchange, chain).block());
+        assertEquals(Boolean.TRUE, exchange.getAttributes().get(AUTH_BOOLEAN_FLAG_NAME));
+    }
+}

--- a/core-services/gateway/src/test/java/com/example/gateway/filters/pre/RequestEnrichmentFilterTenantHeaderTest.java
+++ b/core-services/gateway/src/test/java/com/example/gateway/filters/pre/RequestEnrichmentFilterTenantHeaderTest.java
@@ -1,0 +1,59 @@
+package com.example.gateway.filters.pre;
+
+import com.example.gateway.config.ApplicationProperties;
+import com.example.gateway.utils.CommonUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.example.gateway.constants.GatewayConstants.REQUEST_TENANT_ID_KEY;
+import static com.example.gateway.constants.GatewayConstants.TENANTID_MDC;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * The resolved tenantId must be attached to the request that is actually forwarded downstream — done by
+ * rebuilding the exchange (a bare getRequest().mutate() inside the body-rewrite is discarded by SCG).
+ * These verify the header lands on the exchange passed to the next filter, from the attribute or the
+ * ?tenantId query fallback, and is gated by the propagation flag.
+ */
+class RequestEnrichmentFilterTenantHeaderTest {
+
+    private RequestEnrichmentFilter filter(boolean flag) {
+        ApplicationProperties props = new ApplicationProperties();
+        props.setTenantPropagationEnabled(flag);
+        return new RequestEnrichmentFilter(null, null, new CommonUtils(new ObjectMapper(), null, null), props);
+    }
+
+    private String forwardedTenant(RequestEnrichmentFilter f, MockServerWebExchange exchange) {
+        AtomicReference<ServerWebExchange> captured = new AtomicReference<>();
+        GatewayFilterChain chain = ex -> { captured.set(ex); return Mono.empty(); };
+        f.filter(exchange, chain).block();
+        return captured.get().getRequest().getHeaders().getFirst(REQUEST_TENANT_ID_KEY);
+    }
+
+    @Test
+    void tenantHeaderForwarded_fromQueryParam() {
+        MockServerWebExchange ex = MockServerWebExchange.from(MockServerHttpRequest.get("/x/_search?tenantId=dev").build());
+        assertEquals("dev", forwardedTenant(filter(true), ex));
+    }
+
+    @Test
+    void tenantHeaderForwarded_fromExchangeAttribute() {
+        MockServerWebExchange ex = MockServerWebExchange.from(MockServerHttpRequest.get("/x/_search").build());
+        ex.getAttributes().put(TENANTID_MDC, "dev.city");
+        assertEquals("dev.city", forwardedTenant(filter(true), ex));
+    }
+
+    @Test
+    void noTenantHeader_whenPropagationDisabled() {
+        MockServerWebExchange ex = MockServerWebExchange.from(MockServerHttpRequest.get("/x/_search?tenantId=dev").build());
+        assertNull(forwardedTenant(filter(false), ex));
+    }
+}

--- a/core-services/gateway/src/test/java/com/example/gateway/utils/CommonUtilsResolveTenantForTracingTest.java
+++ b/core-services/gateway/src/test/java/com/example/gateway/utils/CommonUtilsResolveTenantForTracingTest.java
@@ -7,6 +7,9 @@ import org.slf4j.MDC;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static com.example.gateway.constants.GatewayConstants.TENANTID_MDC;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -59,5 +62,21 @@ class CommonUtilsResolveTenantForTracingTest {
         MockServerWebExchange exchange = get("/some/secured/_search?tenantId=dev,dev.city");
         commonUtils.resolveTenantForTracing(exchange, null);
         assertEquals("dev.city", exchange.getAttributes().get(TENANTID_MDC));
+    }
+
+    // POST-body path: tenantId lives in the JSON body (not a query param) and must land in the attribute
+    @Test
+    void postWithTenantInBody_setsTenantAttribute() {
+        MockServerWebExchange exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.post("/some/secured/_create")
+                        .header("Content-Type", "application/json").build());
+        Map<String, Object> individual = new HashMap<>();
+        individual.put("tenantId", "dev");
+        Map<String, Object> body = new HashMap<>();
+        body.put("Individual", individual);
+
+        commonUtils.resolveTenantForTracing(exchange, body);
+
+        assertEquals("dev", exchange.getAttributes().get(TENANTID_MDC));
     }
 }

--- a/core-services/gateway/src/test/java/com/example/gateway/utils/CommonUtilsResolveTenantForTracingTest.java
+++ b/core-services/gateway/src/test/java/com/example/gateway/utils/CommonUtilsResolveTenantForTracingTest.java
@@ -1,0 +1,63 @@
+package com.example.gateway.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+
+import static com.example.gateway.constants.GatewayConstants.TENANTID_MDC;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Tenant propagation for tracing on non-central-instance envs. resolveTenantForTracing must put the
+ * resolved tenantId into the exchange attribute (which RequestEnrichmentFilter then forwards to the
+ * downstream service), resolve nothing gracefully when absent, and never override an already-resolved
+ * tenantId. It must never throw — tracing must not break a request.
+ */
+class CommonUtilsResolveTenantForTracingTest {
+
+    // resolveTenantForTracing's GET/query-param path uses only ObjectMapper; the other deps are unused here.
+    private final CommonUtils commonUtils = new CommonUtils(new ObjectMapper(), null, null);
+
+    @AfterEach
+    void clearMdc() {
+        MDC.clear();
+    }
+
+    private MockServerWebExchange get(String uri) {
+        return MockServerWebExchange.from(MockServerHttpRequest.get(uri).build());
+    }
+
+    @Test
+    void getWithTenantQueryParam_setsTenantAttribute() {
+        MockServerWebExchange exchange = get("/some/secured/_search?tenantId=dev");
+        commonUtils.resolveTenantForTracing(exchange, null);
+        assertEquals("dev", exchange.getAttributes().get(TENANTID_MDC));
+    }
+
+    @Test
+    void getWithoutTenant_setsNothing_andDoesNotThrow() {
+        MockServerWebExchange exchange = get("/some/secured/_search");
+        assertDoesNotThrow(() -> commonUtils.resolveTenantForTracing(exchange, null));
+        assertNull(exchange.getAttributes().get(TENANTID_MDC));
+    }
+
+    @Test
+    void alreadyResolvedTenant_isNotOverwritten() {
+        MockServerWebExchange exchange = get("/some/secured/_search?tenantId=dev");
+        exchange.getAttributes().put(TENANTID_MDC, "pre-set");
+        commonUtils.resolveTenantForTracing(exchange, null);
+        assertEquals("pre-set", exchange.getAttributes().get(TENANTID_MDC));
+    }
+
+    @Test
+    void commaSeparatedTenants_picksMostSpecific() {
+        MockServerWebExchange exchange = get("/some/secured/_search?tenantId=dev,dev.city");
+        commonUtils.resolveTenantForTracing(exchange, null);
+        assertEquals("dev.city", exchange.getAttributes().get(TENANTID_MDC));
+    }
+}


### PR DESCRIPTION
 **Problem:** downstream services were logging an empty `TENANTID`. Two reasons — the `x-tenant-id` header was only added when `is.environment.central.instance=true`, and even when added it
  was dropped, because `getRequest().mutate()` inside the `ModifyRequestBody` rewrite doesn't survive to the forwarded request in Spring Cloud Gateway.

  **Fix:**
  - New `CommonUtils.resolveTenantForTracing()` — resolves `tenantId` from the `?tenantId=` query param or the request body, puts it in MDC and the exchange attribute. Idempotent, never
  throws.
  - `RequestEnrichmentFilter` rebuilds the exchange so `x-tenant-id` and `x-correlation-id` actually reach the downstream route (both GET/form and body-rewrite paths).
  - `RbacFilter`, `RbacFilterHelper`, `UserUtils`, `RequestEnrichmentFilterHelper` now send the tenant header whenever a tenant is resolved, instead of only on central-instance envs.
  - New flag `egov.gateway.tenant.propagation.enabled` (default `true`) as a kill switch.

  Also bumps the build baseline the target branch is missing: Spring Boot 3.2.2 → 3.4.5, Spring Cloud BOM 2024.0.1, tracer 2.9.2, services-common 2.9.1, CVE pins, gateway → `1.0.5-SNAPSHOT`.

  **Tests:** 9 new tests across 3 classes covering tenant resolution (query param, body, comma-separated, absent, already-set), the forwarded header with the flag on/off, and a GET
  header-auth anti-regression.