### PR TITLE
cache MDMS id-format/city lookups to survive bulk generation in idgen service

### DIFF
--- a/core-services/egov-idgen/pom.xml
+++ b/core-services/egov-idgen/pom.xml
@@ -105,6 +105,14 @@
       <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-cache</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.2</version>

--- a/core-services/egov-idgen/src/main/java/org/egov/PtIdGenerationApplication.java
+++ b/core-services/egov-idgen/src/main/java/org/egov/PtIdGenerationApplication.java
@@ -3,15 +3,17 @@ package org.egov;
 import org.egov.tracer.config.TracerConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Import;
 
 /**
  * Description : This is initialization class for pt-idGeneration module
- * 
+ *
  * @author Pavan Kumar Kamma
  *
  */
 @SpringBootApplication
+@EnableCaching
 @Import({TracerConfiguration.class})
 public class PtIdGenerationApplication {
 	public static void main(String[] args) {

--- a/core-services/egov-idgen/src/main/java/org/egov/id/config/CacheConfig.java
+++ b/core-services/egov-idgen/src/main/java/org/egov/id/config/CacheConfig.java
@@ -1,0 +1,48 @@
+package org.egov.id.config;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+/**
+ * Caches the (static) MDMS master data used during ID generation - the ID
+ * format for a given idName+tenant and the city code for a tenant.
+ *
+ * This data is configuration that does not change during a bulk run, so caching
+ * it removes the per-ID MDMS call that previously overwhelmed egov-mdms-service
+ * during bulk user creation (e.g. 10000 users -> ~10000 MDMS calls). With the
+ * cache in place a bulk run makes ~1 MDMS call per distinct (tenant, idName).
+ *
+ * A time-to-live is applied so that a genuine MDMS change eventually propagates
+ * without a service restart.
+ */
+@Configuration
+public class CacheConfig {
+
+    /** Cache of the ID format string, keyed by tenantId + idName. */
+    public static final String ID_FORMAT_CACHE = "idFormatCache";
+
+    /** Cache of the city code, keyed by tenantId. */
+    public static final String CITY_CODE_CACHE = "cityCodeCache";
+
+    @Value("${idgen.mdms.cache.ttl.minutes:60}")
+    private long ttlMinutes;
+
+    @Value("${idgen.mdms.cache.max.size:1000}")
+    private long maxSize;
+
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager(ID_FORMAT_CACHE, CITY_CODE_CACHE);
+        cacheManager.setCaffeine(Caffeine.newBuilder()
+                .expireAfterWrite(ttlMinutes, TimeUnit.MINUTES)
+                .maximumSize(maxSize));
+        return cacheManager;
+    }
+}

--- a/core-services/egov-idgen/src/main/java/org/egov/id/service/MdmsService.java
+++ b/core-services/egov-idgen/src/main/java/org/egov/id/service/MdmsService.java
@@ -12,8 +12,10 @@ import org.egov.mdms.model.MdmsCriteriaReq;
 import org.egov.mdms.model.MdmsResponse;
 import org.egov.mdms.model.ModuleDetail;
 import org.egov.mdms.service.MdmsClientService;
+import org.egov.id.config.CacheConfig;
 import org.egov.tracer.model.CustomException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import com.jayway.jsonpath.DocumentContext;
@@ -61,6 +63,7 @@ public class MdmsService {
      * @throws Exception
      */
 
+    @Cacheable(cacheNames = CacheConfig.CITY_CODE_CACHE, key = "#idRequest.tenantId", unless = "#result == null")
     public String getCity(RequestInfo requestInfo, IdRequest idRequest) {
         Map<String, String> getCity = doMdmsServiceCall(requestInfo, idRequest);
         String cityCode = null;
@@ -88,6 +91,7 @@ public class MdmsService {
      * @throws Exception
      */
 
+    @Cacheable(cacheNames = CacheConfig.ID_FORMAT_CACHE, key = "#idRequest.tenantId + ':' + #idRequest.idName", unless = "#result == null")
     public String getIdFormat(RequestInfo requestInfo, IdRequest idRequest) {
         Map<String, String> getIdFormat = doMdmsServiceCall(requestInfo, idRequest);
         String idFormat = null;

--- a/core-services/egov-idgen/src/main/resources/application.properties
+++ b/core-services/egov-idgen/src/main/resources/application.properties
@@ -26,6 +26,12 @@ management.endpoints.web.base-path=/
 mdms.service.host=https://dev.digit.org/
 mdms.service.search.uri=egov-mdms-service/v1/_search
 
+# MDMS cache: ID format and city code are static master data, cached to avoid a
+# per-ID MDMS call during bulk generation. TTL lets a genuine MDMS change
+# propagate without a restart.
+idgen.mdms.cache.ttl.minutes=60
+idgen.mdms.cache.max.size=1000
+
 id.timezone=IST
 otel.traces.exporter=otlp
 otel.service.name=egov-idgen

--- a/core-services/egov-idgen/src/test/java/org/egov/id/service/MdmsServiceCacheTest.java
+++ b/core-services/egov-idgen/src/test/java/org/egov/id/service/MdmsServiceCacheTest.java
@@ -1,0 +1,115 @@
+package org.egov.id.service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import net.minidev.json.JSONArray;
+import org.egov.id.config.CacheConfig;
+import org.egov.id.model.IdRequest;
+import org.egov.id.model.RequestInfo;
+import org.egov.mdms.model.MasterDetail;
+import org.egov.mdms.model.MdmsResponse;
+import org.egov.mdms.service.MdmsClientService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies that the MDMS ID-format lookup is served from the cache after the
+ * first fetch, so a bulk generation run does not fan out into one MDMS call per
+ * ID. Mocks the MDMS boundary ({@link MdmsClientService}) and counts how often
+ * it is actually invoked.
+ */
+@ContextConfiguration(classes = {CacheConfig.class, MdmsService.class, MdmsServiceCacheTest.CachingConfig.class})
+@ExtendWith(SpringExtension.class)
+class MdmsServiceCacheTest {
+
+    /** Turns on Spring's caching proxy and resolves the ${...} defaults in CacheConfig. */
+    @EnableCaching
+    static class CachingConfig {
+        @Bean
+        static PropertySourcesPlaceholderConfigurer propertyConfigurer() {
+            return new PropertySourcesPlaceholderConfigurer();
+        }
+    }
+
+    private static final String TENANT = "pb.amritsar";
+    private static final String ID_NAME = "boundary.city";
+    private static final String FORMAT = "PB-[SEQ_TEST]";
+
+    private static final String COMMON_MASTERS_MODULE = "common-masters";
+    private static final String ID_FORMAT_MASTER = "IdFormat";
+
+    @MockBean
+    private MdmsClientService mdmsClientService;
+
+    @Autowired
+    private MdmsService mdmsService;
+
+    private MdmsResponse formatResponse() {
+        Map<String, Object> formatObj = new HashMap<>();
+        formatObj.put("format", FORMAT);
+        JSONArray formatArray = new JSONArray();
+        formatArray.add(formatObj);
+        Map<String, JSONArray> commonMasters = new HashMap<>();
+        commonMasters.put(ID_FORMAT_MASTER, formatArray);
+        Map<String, Map<String, JSONArray>> mdmsRes = new HashMap<>();
+        mdmsRes.put(COMMON_MASTERS_MODULE, commonMasters);
+        MdmsResponse response = new MdmsResponse();
+        response.setMdmsRes(mdmsRes);
+        return response;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void stubMdms() {
+        when(mdmsClientService.getMaster((org.egov.common.contract.request.RequestInfo) any(), any(String.class),
+                (Map<String, List<MasterDetail>>) any())).thenReturn(formatResponse());
+    }
+
+    @SuppressWarnings("unchecked")
+    private void verifyMdmsCalls(int count) {
+        verify(mdmsClientService, times(count)).getMaster((org.egov.common.contract.request.RequestInfo) any(),
+                any(String.class), (Map<String, List<MasterDetail>>) any());
+    }
+
+    @Test
+    void getIdFormat_sameKey_hitsMdmsOnceThenServesFromCache() throws Exception {
+        stubMdms();
+        RequestInfo requestInfo = new RequestInfo();
+        IdRequest idRequest = new IdRequest(ID_NAME, TENANT, null, null);
+
+        // Simulate a bulk run: 10 IDs for the same (tenant, idName).
+        for (int i = 0; i < 10; i++) {
+            assertEquals(FORMAT, mdmsService.getIdFormat(requestInfo, idRequest));
+        }
+
+        // Only the first lookup reaches MDMS; the remaining 9 are cache hits.
+        verifyMdmsCalls(1);
+    }
+
+    @Test
+    void getIdFormat_distinctKeys_hitMdmsOncePerKey() throws Exception {
+        stubMdms();
+        RequestInfo requestInfo = new RequestInfo();
+
+        for (int i = 0; i < 5; i++) {
+            mdmsService.getIdFormat(requestInfo, new IdRequest("idName-" + i, TENANT, null, null));
+        }
+
+        // Cache is keyed by tenantId:idName, so 5 distinct keys => 5 MDMS calls.
+        verifyMdmsCalls(5);
+    }
+}


### PR DESCRIPTION
Adds a small in-memory (Caffeine) cache for the two MDMS master-data lookups used during ID generation:

ID format — for a given tenantId + idName
City code — for a given tenantId
Both of these are static configuration — they don't change during a run. Previously idgen made an MDMS call for every single ID, so a bulk operation (e.g. creating 10,000 users) fanned out
into ~10,000 calls to egov-mdms-service and overwhelmed it.
Changes

CacheConfig — a CaffeineCacheManager with two caches (idFormatCache, cityCodeCache), configurable TTL and max size.
https://github.com/Cacheable on MdmsService.getIdFormat() (key: tenantId:idName) and MdmsService.getCity() (key: tenantId); null results are not cached.
@EnableCaching on the application.
New config properties with sensible defaults.
Adds spring-boot-starter-cache + caffeine dependencies.
Unit test (MdmsServiceCacheTest) mocking the MDMS boundary and asserting it's called once across repeated lookups.
Config (defaults)

idgen.mdms.cache.ttl.minutes=60 # so a genuine MDMS change propagates without a restart
idgen.mdms.cache.max.size=1000

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved response times for city and ID-format lookups through caching.
  * Added configurable cache limits and a 60-minute expiration period.
  * Prevented unsuccessful lookups from being stored in the cache.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->