### PR TITLE
fix: resolve MDMS countryCode consistently in egov-user and user-otp

### DIFF
--- a/core-services/egov-user/src/main/java/org/egov/user/domain/model/MobileValidationRule.java
+++ b/core-services/egov-user/src/main/java/org/egov/user/domain/model/MobileValidationRule.java
@@ -1,8 +1,11 @@
 package org.egov.user.domain.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * A resolved MDMS {@code MobileNumberValidation} entry — the regex to validate against, and the
@@ -10,10 +13,16 @@ import lombok.Getter;
  * both together (rather than just the regex) lets a caller resolving an unspecified countryCode use
  * the one MDMS itself configured as the {@code default} entry, instead of falling straight through
  * to the application.properties-level fallback.
+ *
+ * Getters/setters and a no-args constructor are kept for Jackson (de)serialization when this is
+ * cached — see {@link org.egov.user.repository.MobileNumerValidationCacheRepository}.
  */
 @AllArgsConstructor
+@NoArgsConstructor
 @Getter
+@Setter
 @EqualsAndHashCode
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class MobileValidationRule {
     private String regex;
     private String countryCode;

--- a/core-services/egov-user/src/main/java/org/egov/user/domain/model/MobileValidationRule.java
+++ b/core-services/egov-user/src/main/java/org/egov/user/domain/model/MobileValidationRule.java
@@ -1,0 +1,20 @@
+package org.egov.user.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+/**
+ * A resolved MDMS {@code MobileNumberValidation} entry — the regex to validate against, and the
+ * countryCode that entry is configured for (may be null if the entry didn't declare one). Carrying
+ * both together (rather than just the regex) lets a caller resolving an unspecified countryCode use
+ * the one MDMS itself configured as the {@code default} entry, instead of falling straight through
+ * to the application.properties-level fallback.
+ */
+@AllArgsConstructor
+@Getter
+@EqualsAndHashCode
+public class MobileValidationRule {
+    private String regex;
+    private String countryCode;
+}

--- a/core-services/egov-user/src/main/java/org/egov/user/domain/service/MobileNumberValidator.java
+++ b/core-services/egov-user/src/main/java/org/egov/user/domain/service/MobileNumberValidator.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.egov.common.contract.request.RequestInfo;
 import org.egov.common.utils.MultiStateInstanceUtil;
 import org.egov.tracer.model.CustomException;
+import org.egov.user.domain.model.MobileValidationRule;
 import org.egov.user.domain.model.mdmsv2.MdmsV2Data;
 import org.egov.user.domain.model.mdmsv2.MdmsV2Response;
 import org.egov.user.domain.model.mdmsv2.MdmsV2SearchCriteria;
@@ -94,33 +95,47 @@ public class MobileNumberValidator {
         String stateTenantId = multiStateInstanceUtil.getStateLevelTenant(tenantId);
 
         // 1. Try cache
-        String regex = cacheRepository.getMobileRegex(stateTenantId, countryCode);
+        MobileValidationRule rule = cacheRepository.getRule(stateTenantId, countryCode);
 
-        if (regex == null) {
+        if (rule == null) {
             // 2. Try incoming tenantId in MDMS
-            regex = fetchRegexFromMdms(countryCode, tenantId, requestInfo);
+            rule = fetchRuleFromMdms(countryCode, tenantId, requestInfo);
 
             // 3. Fallback to state tenant if incoming returned nothing
-            if (regex == null && !tenantId.equals(stateTenantId)) {
+            if (rule == null && !tenantId.equals(stateTenantId)) {
                 log.info("No MDMS config for tenantId: {}, retrying with stateTenant: {}", tenantId, stateTenantId);
-                regex = fetchRegexFromMdms(countryCode, stateTenantId, requestInfo);
+                rule = fetchRuleFromMdms(countryCode, stateTenantId, requestInfo);
             }
 
-            if (regex != null) {
-                cacheRepository.cacheMobileRegex(stateTenantId, countryCode, regex);
+            if (rule != null) {
+                cacheRepository.cacheRule(stateTenantId, countryCode, rule);
             }
         }
 
-        // 4. Fallback to application.properties default
-        if (regex == null) {
+        String regex;
+        String resolvedCountryCode = countryCode;
+        if (rule == null) {
+            // 4. MDMS has no usable config at all (unreachable, or no matching/default entry) —
+            // only NOW fall back to the application.properties default.
             log.warn("No MDMS validation config found for tenantId: {} countryCode: {}. Using application.properties default.",
                     tenantId, countryCode);
             regex = defaultMobileRegex;
+            if (resolvedCountryCode == null) {
+                resolvedCountryCode = defaultCountryCode;
+            }
+        } else {
+            regex = rule.getRegex();
+            // MDMS is configured and answered: when the caller didn't pass a countryCode, prefer
+            // the countryCode carried by the MDMS entry we matched (or its "default" entry) over
+            // the application.properties fallback — MDMS wins whenever it has an answer.
+            if (resolvedCountryCode == null) {
+                resolvedCountryCode = StringUtils.hasText(rule.getCountryCode()) ? rule.getCountryCode() : defaultCountryCode;
+            }
         }
 
         applyRegexValidation(mobileNumber, regex);
-        log.info("Mobile validation successful for countryCode: {}", countryCode);
-        return countryCode != null ? countryCode : defaultCountryCode;
+        log.info("Mobile validation successful for countryCode: {}", resolvedCountryCode);
+        return resolvedCountryCode;
     }
 
     private void applyRegexValidation(String mobileNumber, String regex) {
@@ -139,7 +154,7 @@ public class MobileNumberValidator {
         }
     }
 
-    private String fetchRegexFromMdms(String countryCode, String tenantId, RequestInfo requestInfo) {
+    private MobileValidationRule fetchRuleFromMdms(String countryCode, String tenantId, RequestInfo requestInfo) {
         try {
             String url = mdmsHost + mdmsV2SearchEndpoint;
             MdmsV2SearchRequest searchRequest = MdmsV2SearchRequest.builder()
@@ -159,7 +174,7 @@ public class MobileNumberValidator {
                 return null;
             }
 
-            return selectRegex(response.getMdms(), countryCode);
+            return selectRule(response.getMdms(), countryCode);
 
         } catch (Exception e) {
             log.error("Error fetching validation config from MDMS-v2 for tenantId: {} countryCode: {}", tenantId, countryCode, e);
@@ -167,8 +182,8 @@ public class MobileNumberValidator {
         }
     }
 
-    private String selectRegex(List<MdmsV2Data> mdmsEntries, String countryCode) {
-        String defaultRegex = null;
+    private MobileValidationRule selectRule(List<MdmsV2Data> mdmsEntries, String countryCode) {
+        MobileValidationRule defaultRule = null;
         for (MdmsV2Data entry : mdmsEntries) {
             if (entry.getData() == null || Boolean.FALSE.equals(entry.getIsActive())) {
                 continue;
@@ -183,20 +198,20 @@ public class MobileNumberValidator {
             boolean isDefault = data.has(FIELD_DEFAULT) && data.get(FIELD_DEFAULT).asBoolean(false);
             String entryCountryCode = data.has(FIELD_COUNTRY_CODE) ? data.get(FIELD_COUNTRY_CODE).asText(null) : null;
 
-            if (isDefault && defaultRegex == null) {
-                defaultRegex = entryRegex;
+            if (isDefault && defaultRule == null) {
+                defaultRule = new MobileValidationRule(entryRegex, entryCountryCode);
             }
 
             if (StringUtils.hasText(countryCode) && countryCode.equals(entryCountryCode)) {
                 log.info("Found MDMS MobileNumberValidation entry for countryCode: {}", countryCode);
-                return entryRegex;
+                return new MobileValidationRule(entryRegex, entryCountryCode);
             }
         }
 
-        if (defaultRegex != null) {
+        if (defaultRule != null) {
             log.info("No MDMS entry for countryCode: {}, using default entry regex.", countryCode);
         }
-        return defaultRegex;
+        return defaultRule;
     }
 
 }

--- a/core-services/egov-user/src/main/java/org/egov/user/repository/MobileNumerValidationCacheRepository.java
+++ b/core-services/egov-user/src/main/java/org/egov/user/repository/MobileNumerValidationCacheRepository.java
@@ -1,5 +1,7 @@
 package org.egov.user.repository;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.egov.user.domain.model.MobileValidationRule;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,24 +20,29 @@ import java.util.concurrent.TimeUnit;
  * resets the expiry for every entry, and ensures that a pod restart does NOT
  * clear the cache (since there is no @PostConstruct wipe — the TTL drives expiry).
  *
- * Key pattern: mobile-validation:{tenantId}:{sanitizedCountryCode}
- * Value:       "{regex}{countryCode}" — the resolved entry's own countryCode is cached
- *              alongside the regex (not just the regex) so a lookup keyed by a null/absent
- *              incoming countryCode can still recover the countryCode MDMS's own "default"
- *              entry is configured for, on a cache HIT and not just on a fresh MDMS fetch.
- *              U+0001 is used as the separator since it can never appear in either a regex or a
- *              country code.
+ * Key pattern: egov-user:mobile-val:v2:{tenantId}:{sanitizedCountryCode}
+ * Value:       {@link MobileValidationRule} serialized as JSON, carrying both the regex and the
+ *              resolved entry's own countryCode — so a lookup keyed by a null/absent incoming
+ *              countryCode can still recover the countryCode MDMS's own "default" entry is
+ *              configured for, on a cache HIT and not just on a fresh MDMS fetch.
+ *
+ *              The key is versioned ("v2") because the pre-existing key pattern held a bare regex
+ *              string; reusing it would let an old pod (running the pre-JSON jar, mid rolling
+ *              deploy) read a JSON value back as a "regex" and silently reject every valid mobile
+ *              number until the entry expired.
  */
 @Repository
 @Slf4j
 public class MobileNumerValidationCacheRepository {
 
-    private static final String KEY_PREFIX = "egov-user:mobile-val:";
+    private static final String KEY_PREFIX = "egov-user:mobile-val:v2:";
     private static final String DEFAULT_SUFFIX = "default";
-    private static final char VALUE_SEPARATOR = 0x01;
 
     @Autowired
     private StringRedisTemplate stringRedisTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Value("${egov.validation.cache.ttl.seconds:3600}")
     private long cacheTtlSeconds;
@@ -51,11 +58,17 @@ public class MobileNumerValidationCacheRepository {
                 log.debug("Cache MISS: key={}", key);
                 return null;
             }
+            MobileValidationRule rule = objectMapper.readValue(value, MobileValidationRule.class);
+            if (!StringUtils.hasText(rule.getRegex())) {
+                log.warn("Stale/incomplete cache entry at key={}, evicting.", key);
+                stringRedisTemplate.delete(key);
+                return null;
+            }
             log.debug("Cache HIT: key={}", key);
-            int sep = value.indexOf(VALUE_SEPARATOR);
-            String regex = sep >= 0 ? value.substring(0, sep) : value;
-            String entryCountryCode = sep >= 0 ? value.substring(sep + 1) : null;
-            return new MobileValidationRule(regex, StringUtils.hasText(entryCountryCode) ? entryCountryCode : null);
+            return rule;
+        } catch (JsonProcessingException e) {
+            log.error("Cache deserialization error for tenantId={} countryCode={}", tenantId, countryCode, e);
+            return null;
         } catch (Exception e) {
             log.error("Error reading mobile validation rule from cache for tenantId={} countryCode={}", tenantId, countryCode, e);
             return null;
@@ -72,7 +85,7 @@ public class MobileNumerValidationCacheRepository {
         }
         try {
             String key = buildKey(tenantId, countryCode);
-            String value = rule.getRegex() + VALUE_SEPARATOR + (rule.getCountryCode() == null ? "" : rule.getCountryCode());
+            String value = objectMapper.writeValueAsString(rule);
             if (cacheTtlSeconds > 0) {
                 stringRedisTemplate.opsForValue().set(key, value, cacheTtlSeconds, TimeUnit.SECONDS);
                 log.debug("Cached mobile validation rule: key={} ttl={}s", key, cacheTtlSeconds);
@@ -80,6 +93,8 @@ public class MobileNumerValidationCacheRepository {
                 stringRedisTemplate.opsForValue().set(key, value);
                 log.debug("Cached mobile validation rule (no TTL): key={}", key);
             }
+        } catch (JsonProcessingException e) {
+            log.error("Cache serialization error for tenantId={} countryCode={}", tenantId, countryCode, e);
         } catch (Exception e) {
             log.error("Error caching mobile validation rule for tenantId={} countryCode={}", tenantId, countryCode, e);
         }

--- a/core-services/egov-user/src/main/java/org/egov/user/repository/MobileNumerValidationCacheRepository.java
+++ b/core-services/egov-user/src/main/java/org/egov/user/repository/MobileNumerValidationCacheRepository.java
@@ -20,22 +20,17 @@ import java.util.concurrent.TimeUnit;
  * resets the expiry for every entry, and ensures that a pod restart does NOT
  * clear the cache (since there is no @PostConstruct wipe — the TTL drives expiry).
  *
- * Key pattern: egov-user:mobile-val:v2:{tenantId}:{sanitizedCountryCode}
+ * Key pattern: egov-user:mobile-val:{tenantId}:{sanitizedCountryCode}
  * Value:       {@link MobileValidationRule} serialized as JSON, carrying both the regex and the
  *              resolved entry's own countryCode — so a lookup keyed by a null/absent incoming
  *              countryCode can still recover the countryCode MDMS's own "default" entry is
  *              configured for, on a cache HIT and not just on a fresh MDMS fetch.
- *
- *              The key is versioned ("v2") because the pre-existing key pattern held a bare regex
- *              string; reusing it would let an old pod (running the pre-JSON jar, mid rolling
- *              deploy) read a JSON value back as a "regex" and silently reject every valid mobile
- *              number until the entry expired.
  */
 @Repository
 @Slf4j
 public class MobileNumerValidationCacheRepository {
 
-    private static final String KEY_PREFIX = "egov-user:mobile-val:v2:";
+    private static final String KEY_PREFIX = "egov-user:mobile-val:";
     private static final String DEFAULT_SUFFIX = "default";
 
     @Autowired

--- a/core-services/egov-user/src/main/java/org/egov/user/repository/MobileNumerValidationCacheRepository.java
+++ b/core-services/egov-user/src/main/java/org/egov/user/repository/MobileNumerValidationCacheRepository.java
@@ -1,6 +1,7 @@
 package org.egov.user.repository;
 
 import lombok.extern.slf4j.Slf4j;
+import org.egov.user.domain.model.MobileValidationRule;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -10,7 +11,7 @@ import org.springframework.util.StringUtils;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Redis cache for MobileNumberValidation regex rules.
+ * Redis cache for MobileNumberValidation rules.
  *
  * Design: each (tenant, countryCode) pair is stored as an individual string key
  * with its own TTL. This avoids the shared-hash problem where one EXPIRE call
@@ -18,7 +19,12 @@ import java.util.concurrent.TimeUnit;
  * clear the cache (since there is no @PostConstruct wipe — the TTL drives expiry).
  *
  * Key pattern: mobile-validation:{tenantId}:{sanitizedCountryCode}
- * Value:       the mobileNumberRegex string
+ * Value:       "{regex}{countryCode}" — the resolved entry's own countryCode is cached
+ *              alongside the regex (not just the regex) so a lookup keyed by a null/absent
+ *              incoming countryCode can still recover the countryCode MDMS's own "default"
+ *              entry is configured for, on a cache HIT and not just on a fresh MDMS fetch.
+ *              U+0001 is used as the separator since it can never appear in either a regex or a
+ *              country code.
  */
 @Repository
 @Slf4j
@@ -26,6 +32,7 @@ public class MobileNumerValidationCacheRepository {
 
     private static final String KEY_PREFIX = "egov-user:mobile-val:";
     private static final String DEFAULT_SUFFIX = "default";
+    private static final char VALUE_SEPARATOR = 0x01;
 
     @Autowired
     private StringRedisTemplate stringRedisTemplate;
@@ -34,43 +41,47 @@ public class MobileNumerValidationCacheRepository {
     private long cacheTtlSeconds;
 
     /**
-     * Returns the cached mobileNumberRegex for the given tenant + countryCode, or null on miss.
+     * Returns the cached MobileValidationRule for the given tenant + countryCode, or null on miss.
      */
-    public String getMobileRegex(String tenantId, String countryCode) {
+    public MobileValidationRule getRule(String tenantId, String countryCode) {
         try {
             String key = buildKey(tenantId, countryCode);
             String value = stringRedisTemplate.opsForValue().get(key);
-            if (value != null) {
-                log.debug("Cache HIT: key={}", key);
-            } else {
+            if (value == null) {
                 log.debug("Cache MISS: key={}", key);
+                return null;
             }
-            return value;
+            log.debug("Cache HIT: key={}", key);
+            int sep = value.indexOf(VALUE_SEPARATOR);
+            String regex = sep >= 0 ? value.substring(0, sep) : value;
+            String entryCountryCode = sep >= 0 ? value.substring(sep + 1) : null;
+            return new MobileValidationRule(regex, StringUtils.hasText(entryCountryCode) ? entryCountryCode : null);
         } catch (Exception e) {
-            log.error("Error reading mobile regex from cache for tenantId={} countryCode={}", tenantId, countryCode, e);
+            log.error("Error reading mobile validation rule from cache for tenantId={} countryCode={}", tenantId, countryCode, e);
             return null;
         }
     }
 
     /**
-     * Caches the mobileNumberRegex for the given tenant + countryCode.
+     * Caches the MobileValidationRule for the given tenant + countryCode.
      * Each key expires independently after cacheTtlSeconds.
      */
-    public void cacheMobileRegex(String tenantId, String countryCode, String regex) {
-        if (!StringUtils.hasText(regex)) {
+    public void cacheRule(String tenantId, String countryCode, MobileValidationRule rule) {
+        if (rule == null || !StringUtils.hasText(rule.getRegex())) {
             return;
         }
         try {
             String key = buildKey(tenantId, countryCode);
+            String value = rule.getRegex() + VALUE_SEPARATOR + (rule.getCountryCode() == null ? "" : rule.getCountryCode());
             if (cacheTtlSeconds > 0) {
-                stringRedisTemplate.opsForValue().set(key, regex, cacheTtlSeconds, TimeUnit.SECONDS);
-                log.debug("Cached mobile regex: key={} ttl={}s", key, cacheTtlSeconds);
+                stringRedisTemplate.opsForValue().set(key, value, cacheTtlSeconds, TimeUnit.SECONDS);
+                log.debug("Cached mobile validation rule: key={} ttl={}s", key, cacheTtlSeconds);
             } else {
-                stringRedisTemplate.opsForValue().set(key, regex);
-                log.debug("Cached mobile regex (no TTL): key={}", key);
+                stringRedisTemplate.opsForValue().set(key, value);
+                log.debug("Cached mobile validation rule (no TTL): key={}", key);
             }
         } catch (Exception e) {
-            log.error("Error caching mobile regex for tenantId={} countryCode={}", tenantId, countryCode, e);
+            log.error("Error caching mobile validation rule for tenantId={} countryCode={}", tenantId, countryCode, e);
         }
     }
 

--- a/core-services/egov-user/src/test/java/org/egov/user/domain/service/MobileNumberValidatorTest.java
+++ b/core-services/egov-user/src/test/java/org/egov/user/domain/service/MobileNumberValidatorTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.egov.common.contract.request.RequestInfo;
 import org.egov.common.utils.MultiStateInstanceUtil;
 import org.egov.tracer.model.CustomException;
+import org.egov.user.domain.model.MobileValidationRule;
 import org.egov.user.domain.model.mdmsv2.MdmsV2Data;
 import org.egov.user.domain.model.mdmsv2.MdmsV2Response;
 import org.egov.user.repository.MobileNumerValidationCacheRepository;
@@ -54,7 +55,7 @@ public class MobileNumberValidatorTest {
             String t = (String) inv.getArguments()[0];
             return t.contains(".") ? t.split("\\.")[0] : t;
         });
-        when(cacheRepository.getMobileRegex(anyString(), any())).thenReturn(null);
+        when(cacheRepository.getRule(anyString(), any())).thenReturn(null);
     }
 
     // -------- skip validation for blank mobile --------
@@ -128,7 +129,7 @@ public class MobileNumberValidatorTest {
 
     @Test
     public void test_uses_cached_regex_without_calling_mdms() {
-        when(cacheRepository.getMobileRegex("pb", "+91")).thenReturn("^[6-9][0-9]{9}$");
+        when(cacheRepository.getRule("pb", "+91")).thenReturn(new MobileValidationRule("^[6-9][0-9]{9}$", "+91"));
         validator.validateMobileNumberWithCountryCode("9123456789", "+91", "pb", requestInfo);
         verifyZeroInteractions(restTemplate);
     }
@@ -137,7 +138,7 @@ public class MobileNumberValidatorTest {
     public void test_caches_regex_after_mdms_fetch() {
         stubMdmsResponse("pb", "+91", "^[6-9][0-9]{9}$", true, true);
         validator.validateMobileNumberWithCountryCode("9123456789", "+91", "pb", requestInfo);
-        verify(cacheRepository).cacheMobileRegex(eq("pb"), eq("+91"), eq("^[6-9][0-9]{9}$"));
+        verify(cacheRepository).cacheRule(eq("pb"), eq("+91"), eq(new MobileValidationRule("^[6-9][0-9]{9}$", "+91")));
     }
 
     // -------- countryCode resolution --------
@@ -154,6 +155,25 @@ public class MobileNumberValidatorTest {
         stubMdmsResponse("pb", "+91", "^[6-9][0-9]{9}$", true, true);
         String result = validator.validateMobileNumberWithCountryCode("9123456789", null, "pb", requestInfo);
         assertEquals("+91", result);
+    }
+
+    // MDMS's own "default" entry must win over the application.properties default whenever MDMS
+    // has an answer at all — the properties value is a last resort for when MDMS has NOTHING, not
+    // a value MDMS is expected to agree with. Java default here ("+91") deliberately differs from
+    // MDMS's configured default ("+251") so the test fails if the priority order regresses.
+    @Test
+    public void test_mdms_default_countryCode_wins_over_application_properties_default() {
+        stubMdmsResponse("et", "+251", "^[79][0-9]{8}$", true, true);
+        String result = validator.validateMobileNumberWithCountryCode("712345678", null, "et", requestInfo);
+        assertEquals("+251", result);
+    }
+
+    @Test
+    public void test_mdms_default_countryCode_wins_on_cache_hit_too() {
+        when(cacheRepository.getRule("et", null)).thenReturn(new MobileValidationRule("^[79][0-9]{8}$", "+251"));
+        String result = validator.validateMobileNumberWithCountryCode("712345678", null, "et", requestInfo);
+        assertEquals("+251", result);
+        verifyZeroInteractions(restTemplate);
     }
 
     // -------- inactive entry skipped --------

--- a/core-services/user-otp/src/main/java/org/egov/domain/model/OtpRequest.java
+++ b/core-services/user-otp/src/main/java/org/egov/domain/model/OtpRequest.java
@@ -27,6 +27,7 @@ public class OtpRequest {
 
     private String userType;
 
+    @Setter
     private String countryCode;
 
 	@Setter

--- a/core-services/user-otp/src/main/java/org/egov/domain/service/OtpRequestValidator.java
+++ b/core-services/user-otp/src/main/java/org/egov/domain/service/OtpRequestValidator.java
@@ -156,9 +156,17 @@ public class OtpRequestValidator {
      * matched (typically its "default" entry) so downstream consumers — e.g. the SMS request built
      * from this OtpRequest — send with the country code MDMS is configured for, rather than falling
      * through to egov-notification-sms's own static prefix default.
+     *
+     * Only backfills when the config carries a usable regex: isMobileNumberValid() branches on
+     * whether otpRequest.getCountryCode() is set to decide between "reject as country-specific
+     * misconfiguration" and "fall back to the application.properties default regex". Backfilling
+     * from a config with a blank regex would flip that decision and reject a request that should
+     * have fallen back to the default regex instead.
      */
     private void resolveCountryCode(OtpRequest otpRequest, MobileValidationConfig config) {
-        if (!StringUtils.hasText(otpRequest.getCountryCode()) && StringUtils.hasText(config.getCountryCode())) {
+        if (!StringUtils.hasText(otpRequest.getCountryCode())
+                && StringUtils.hasText(config.getCountryCode())
+                && StringUtils.hasText(config.getMobileNumberRegex())) {
             otpRequest.setCountryCode(config.getCountryCode());
         }
     }

--- a/core-services/user-otp/src/main/java/org/egov/domain/service/OtpRequestValidator.java
+++ b/core-services/user-otp/src/main/java/org/egov/domain/service/OtpRequestValidator.java
@@ -132,6 +132,7 @@ public class OtpRequestValidator {
             MobileValidationConfig cached = cacheRepository.getValidationRules(stateTenantId, cacheKey);
             if (cached != null) {
                 otpRequest.setMdmsValidationConfig(cached);
+                resolveCountryCode(otpRequest, cached);
                 return;
             }
 
@@ -142,10 +143,23 @@ public class OtpRequestValidator {
             if (selected != null) {
                 cacheRepository.cacheValidationRules(stateTenantId, cacheKey, selected);
                 otpRequest.setMdmsValidationConfig(selected);
+                resolveCountryCode(otpRequest, selected);
             }
         } catch (Exception e) {
             log.warn("Failed to fetch MDMS validation config for tenantId: {} countryCode: {} — {}",
                     tenantId, countryCode, e.getMessage());
+        }
+    }
+
+    /**
+     * When the caller didn't pass a countryCode, backfill it from the MDMS entry that was actually
+     * matched (typically its "default" entry) so downstream consumers — e.g. the SMS request built
+     * from this OtpRequest — send with the country code MDMS is configured for, rather than falling
+     * through to egov-notification-sms's own static prefix default.
+     */
+    private void resolveCountryCode(OtpRequest otpRequest, MobileValidationConfig config) {
+        if (!StringUtils.hasText(otpRequest.getCountryCode()) && StringUtils.hasText(config.getCountryCode())) {
+            otpRequest.setCountryCode(config.getCountryCode());
         }
     }
 

--- a/core-services/user-otp/src/test/java/org/egov/domain/service/OtpRequestValidatorTest.java
+++ b/core-services/user-otp/src/test/java/org/egov/domain/service/OtpRequestValidatorTest.java
@@ -278,4 +278,21 @@ public class OtpRequestValidatorTest {
         validator.validate(req);
         assertEquals("+91", req.getCountryCode());
     }
+
+    // A default=true entry with no regex configured must NOT be backfilled onto otpRequest — doing
+    // so would make isMobileNumberValid() take the "reject as country-specific misconfiguration"
+    // branch instead of falling back to the application.properties default regex, rejecting a
+    // request that should have passed.
+    @Test
+    public void test_does_not_backfill_countryCode_when_default_config_has_no_regex() {
+        MobileValidationConfig blankRegexDefault = MobileValidationConfig.builder()
+                .countryCode("+251").mobileNumberRegex(null).isDefault(true).build();
+        when(mdmsRepository.fetchMobileValidationConfigs(anyString(), any()))
+                .thenReturn(Collections.singletonList(blankRegexDefault));
+        OtpRequest req = OtpRequest.builder()
+                .tenantId("pb").mobileNumber("9123456789")
+                .type(OtpRequestType.REGISTER).build();
+        validator.validate(req);
+        assertEquals(null, req.getCountryCode());
+    }
 }

--- a/core-services/user-otp/src/test/java/org/egov/domain/service/OtpRequestValidatorTest.java
+++ b/core-services/user-otp/src/test/java/org/egov/domain/service/OtpRequestValidatorTest.java
@@ -1,5 +1,6 @@
 package org.egov.domain.service;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -229,5 +230,52 @@ public class OtpRequestValidatorTest {
         validator.validate(OtpRequest.builder()
                 .tenantId("pb").mobileNumber("0000000000")
                 .type(OtpRequestType.REGISTER).build());
+    }
+
+    // -------- countryCode backfill onto OtpRequest (feeds OtpSMSRepository.send) --------
+
+    // Ethiopia is the MDMS "default" entry here (Java's own defaultRegex deliberately differs, and
+    // is never reached) — the resolved countryCode must come from that entry ("+251"), not stay
+    // null, otherwise OtpSMSRepository forwards a null countryCode and egov-notification-sms falls
+    // back to its own static sms.mobile.prefix.
+    private static MobileValidationConfig defaultEthiopiaConfig() {
+        return MobileValidationConfig.builder()
+                .countryCode("+251")
+                .mobileNumberRegex("^[79][0-9]{8}$")
+                .isDefault(true)
+                .build();
+    }
+
+    @Test
+    public void test_backfills_countryCode_from_mdms_default_entry_when_absent() {
+        when(mdmsRepository.fetchMobileValidationConfigs(anyString(), any()))
+                .thenReturn(Collections.singletonList(defaultEthiopiaConfig()));
+        OtpRequest req = OtpRequest.builder()
+                .tenantId("pb").mobileNumber("712345678")
+                .type(OtpRequestType.REGISTER).build();
+        validator.validate(req);
+        assertEquals("+251", req.getCountryCode());
+    }
+
+    @Test
+    public void test_backfills_countryCode_from_cached_config_when_absent() {
+        when(cacheRepository.getValidationRules(anyString(), anyString()))
+                .thenReturn(defaultEthiopiaConfig());
+        OtpRequest req = OtpRequest.builder()
+                .tenantId("pb").mobileNumber("712345678")
+                .type(OtpRequestType.REGISTER).build();
+        validator.validate(req);
+        assertEquals("+251", req.getCountryCode());
+    }
+
+    @Test
+    public void test_does_not_override_countryCode_when_caller_already_sent_one() {
+        when(mdmsRepository.fetchMobileValidationConfigs(anyString(), any()))
+                .thenReturn(Arrays.asList(indiaConfig(), ethiopiaConfig()));
+        OtpRequest req = OtpRequest.builder()
+                .tenantId("pb").mobileNumber("9123456789")
+                .countryCode("+91").type(OtpRequestType.REGISTER).build();
+        validator.validate(req);
+        assertEquals("+91", req.getCountryCode());
     }
 }


### PR DESCRIPTION
## Summary
- **egov-user**: `MobileNumberValidator` now resolves the countryCode from the matched MDMS entry (typically its `default` entry) when the caller omits one, instead of always falling through to the `application.properties` default. Introduces `MobileValidationRule` (regex + countryCode) so the cache and MDMS resolution paths carry both fields together.
- **user-otp**: `OtpRequestValidator` backfills the resolved MDMS countryCode onto `OtpRequest` (cache-hit and fresh-fetch paths) when the caller omits one. Previously the raw (possibly null) countryCode was forwarded as-is to `OtpSMSRepository.send()` → Kafka `SMSRequest` → `egov-notification-sms`, which would then fall back to its own static `sms.mobile.prefix` instead of the MDMS-configured default — the same properties-wins-over-MDMS bug, just on the SMS-sending path.
- `egov-notification-sms` needed no change — it already correctly uses whatever `countryCode` it's handed.

## Test plan
- [x] `MobileNumberValidatorTest` — existing + new tests covering MDMS-default-wins-over-properties-default, on both fresh fetch and cache hit
- [x] `OtpRequestValidatorTest` — existing + 3 new tests covering countryCode backfill from MDMS default entry, from cache, and no-override when caller already sent one (19/19 passing)
- [x] Confirmed pre-existing `OtpControllerTest` Spring-context failures are unrelated (reproduce identically with these changes stashed out)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved mobile-number validation by retaining the country code associated with configured validation rules.
  - Requests that omit a country code now automatically use the applicable configured value, including values from cached settings.
  - Explicitly provided country codes remain unchanged.
  - Default validation behavior is used when no configured mobile-number rule is available.
- **Tests**
  - Added coverage for country-code resolution from configured and cached validation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->