### PR TITLE
Add count API to mdms-v2 service

### DIFF
--- a/core-services/docs/mdms-v2-contract.yml
+++ b/core-services/docs/mdms-v2-contract.yml
@@ -14,6 +14,10 @@ info:
     email: contacts@egovernments.org
 schemes:
   - https
+consumes:
+  - application/json
+produces:
+  - application/json
 basePath: /mdms-v2
 x-api-id: org.egov.infra.mdms.service
 x-common-path: 'https://raw.githubusercontent.com/egovernments/egov-services/master/docs/common/contracts/v1-1-1.yml'

--- a/core-services/docs/mdms-v2-contract.yml
+++ b/core-services/docs/mdms-v2-contract.yml
@@ -4,10 +4,11 @@ info:
   title: eGov MDMS V2 Service.
   description: |
     APIs for Master Data Management V2 service. This service reads/writes generic master data (validated against a registered JSON schema) and exposes it via REST API. This module handles the below functionality.
-    1. Create master data against a registered schema
-    2. Search master data using a common criteria model, with tenant-level fallback
-    3. Update existing master data
-    4. Count master data matching a search criteria, without fetching the actual records
+    1. Register/search JSON schema definitions that master data is validated against
+    2. Create master data against a registered schema
+    3. Search master data using a common criteria model, with tenant-level fallback
+    4. Update existing master data
+    5. Count master data matching a search criteria, without fetching the actual records
   contact:
     name: eGovernments Foundation
     email: contacts@egovernments.org
@@ -17,6 +18,69 @@ basePath: /mdms-v2
 x-api-id: org.egov.infra.mdms.service
 x-common-path: 'https://raw.githubusercontent.com/egovernments/egov-services/master/docs/common/contracts/v1-1-1.yml'
 paths:
+  /schema/v1/_create:
+    post:
+      summary: Register a new JSON schema definition.
+      description: |
+        Registers a new schema definition (a JSON schema keyed by a unique `code`) that master data records are validated against on create/update via /v2/_create/{schemaCode} and /v2/_update/{schemaCode}.
+      parameters:
+        - name: SchemaDefinitionRequest
+          in: body
+          description: Details for the new schema definition + RequestInfo meta data.
+          required: true
+          schema:
+            $ref: '#/definitions/SchemaDefinitionRequest'
+      responses:
+        '202':
+          description: ResponseInfo with schema definition accepted for creation.
+          schema:
+            $ref: '#/definitions/SchemaDefinitionResponse'
+        '400':
+          description: Schema definition creation failed.
+          schema:
+            $ref: 'https://raw.githubusercontent.com/egovernments/egov-services/master/docs/common/contracts/v1-0-0.yml#/definitions/ErrorRes'
+      tags:
+        - MDMS V2 Schema
+  /schema/v1/_search:
+    post:
+      summary: Search registered JSON schema definitions.
+      description: |
+        Fetches schema definitions matching SchemaDefCriteria (tenantId, codes), with pagination via offset/limit.
+      parameters:
+        - name: SchemaDefSearchRequest
+          in: body
+          description: RequestInfo meta data + SchemaDefCriteria to search schema definitions by.
+          required: true
+          schema:
+            $ref: '#/definitions/SchemaDefSearchRequest'
+      responses:
+        '202':
+          description: Schema definitions retrieved successfully.
+          schema:
+            $ref: '#/definitions/SchemaDefinitionResponse'
+        '400':
+          description: Invalid input.
+          schema:
+            $ref: 'https://raw.githubusercontent.com/egovernments/egov-services/master/docs/common/contracts/v1-1-1.yml#/definitions/ErrorRes'
+      tags:
+        - MDMS V2 Schema
+  /schema/v1/_update:
+    post:
+      summary: Update an existing JSON schema definition. Not yet implemented.
+      description: |
+        Reserved for updating an existing schema definition. Currently returns HTTP 501 (Not Implemented).
+      parameters:
+        - name: SchemaDefinitionRequest
+          in: body
+          description: Details of the schema definition to update + RequestInfo meta data.
+          required: true
+          schema:
+            $ref: '#/definitions/SchemaDefinitionRequest'
+      responses:
+        '501':
+          description: Not implemented.
+      tags:
+        - MDMS V2 Schema
   /v2/_create/{schemaCode}:
     post:
       summary: Create new master data for a given schema.
@@ -125,6 +189,104 @@ paths:
         - MDMS V2
 
 definitions:
+  SchemaDefinition:
+    type: object
+    description: A registered JSON schema that master data records are validated against.
+    properties:
+      id:
+        type: string
+        description: Unique identifier (UUID) of the schema definition.
+        minLength: 2
+        maxLength: 128
+        readOnly: true
+      tenantId:
+        type: string
+        description: Unique Identifier of ULB/tenant the schema definition belongs to.
+        minLength: 2
+        maxLength: 128
+      code:
+        type: string
+        description: Unique code identifying the schema (e.g. 'common-masters.Department'), referenced as schemaCode by /v2/_create, /v2/_search, /v2/_count and /v2/_update.
+        minLength: 2
+        maxLength: 128
+      description:
+        type: string
+        description: Human readable description of the schema.
+        minLength: 2
+        maxLength: 512
+      definition:
+        type: object
+        description: The JSON schema (draft) definition itself, used to validate master data payloads.
+      isActive:
+        type: boolean
+        description: Denotes whether the schema definition is active.
+        default: true
+      auditDetails:
+        $ref: 'https://raw.githubusercontent.com/egovernments/egov-services/master/docs/common/contracts/v1-0-0.yml#/definitions/AuditDetails'
+    required:
+      - tenantId
+      - code
+      - definition
+
+  SchemaDefinitionRequest:
+    type: object
+    description: Contract class to receive create/update requests for a single SchemaDefinition.
+    properties:
+      RequestInfo:
+        $ref: 'https://raw.githubusercontent.com/egovernments/egov-services/master/docs/common/contracts/v1-1-1.yml#/definitions/RequestInfo'
+      SchemaDefinition:
+        $ref: '#/definitions/SchemaDefinition'
+    required:
+      - RequestInfo
+      - SchemaDefinition
+
+  SchemaDefCriteria:
+    type: object
+    description: Search criteria for schema definitions.
+    properties:
+      tenantId:
+        type: string
+        description: Unique Identifier of ULB/tenant to search schema definitions for.
+        minLength: 1
+        maxLength: 100
+      codes:
+        type: array
+        description: List of schema codes to filter by.
+        items:
+          type: string
+      offset:
+        type: integer
+        description: Number of records to skip.
+      limit:
+        type: integer
+        description: Maximum number of records to return.
+    required:
+      - tenantId
+
+  SchemaDefSearchRequest:
+    type: object
+    description: Contract class to receive schema definition search requests.
+    properties:
+      RequestInfo:
+        $ref: 'https://raw.githubusercontent.com/egovernments/egov-services/master/docs/common/contracts/v1-1-1.yml#/definitions/RequestInfo'
+      SchemaDefCriteria:
+        $ref: '#/definitions/SchemaDefCriteria'
+    required:
+      - RequestInfo
+      - SchemaDefCriteria
+
+  SchemaDefinitionResponse:
+    type: object
+    description: Contract class to send the response for schema definition create/search.
+    properties:
+      ResponseInfo:
+        $ref: 'https://raw.githubusercontent.com/egovernments/egov-services/master/docs/common/contracts/v1-0-0.yml#/definitions/ResponseInfo'
+      SchemaDefinitions:
+        type: array
+        description: List of schema definitions.
+        items:
+          $ref: '#/definitions/SchemaDefinition'
+
   Mdms:
     type: object
     description: A single master data record, validated against a registered JSON schema.

--- a/core-services/docs/mdms-v2-contract.yml
+++ b/core-services/docs/mdms-v2-contract.yml
@@ -354,10 +354,10 @@ definitions:
       uniqueIdentifiers:
         type: array
         description: List of business unique identifiers to filter by.
+        minItems: 1
+        maxItems: 64
         items:
           type: string
-          minLength: 1
-          maxLength: 64
       schemaCode:
         type: string
         description: Schema code to filter master data by (e.g. 'common-masters.Department').
@@ -380,7 +380,9 @@ definitions:
 
   MdmsCriteriaReqV2:
     type: object
-    description: Contract class to receive search/count requests, shared unchanged between /v2/_search and /v2/_count.
+    description: |
+      Contract class to receive search/count requests, shared unchanged between /v2/_search and /v2/_count.
+      Note: MdmsCriteria is functionally required (its absence causes a NullPointerException downstream) but is not enforced by bean validation - the field carries only @Valid, not @NotNull.
     properties:
       RequestInfo:
         $ref: 'https://raw.githubusercontent.com/egovernments/egov-services/master/docs/common/contracts/v1-1-1.yml#/definitions/RequestInfo'

--- a/core-services/docs/mdms-v2-contract.yml
+++ b/core-services/docs/mdms-v2-contract.yml
@@ -1,0 +1,251 @@
+swagger: '2.0'
+info:
+  version: 1.0.0
+  title: eGov MDMS V2 Service.
+  description: |
+    APIs for Master Data Management V2 service. This service reads/writes generic master data (validated against a registered JSON schema) and exposes it via REST API. This module handles the below functionality.
+    1. Create master data against a registered schema
+    2. Search master data using a common criteria model, with tenant-level fallback
+    3. Update existing master data
+    4. Count master data matching a search criteria, without fetching the actual records
+  contact:
+    name: eGovernments Foundation
+    email: contacts@egovernments.org
+schemes:
+  - https
+basePath: /mdms-v2
+x-api-id: org.egov.infra.mdms.service
+x-common-path: 'https://raw.githubusercontent.com/egovernments/egov-services/master/docs/common/contracts/v1-1-1.yml'
+paths:
+  /v2/_create/{schemaCode}:
+    post:
+      summary: Create new master data for a given schema.
+      description: |
+        Creates a new master data record against the JSON schema identified by schemaCode. The request payload (Mdms.data) is validated against the registered schema before being persisted.
+      parameters:
+        - name: schemaCode
+          in: path
+          description: Unique code of the schema definition the master data conforms to.
+          required: true
+          type: string
+        - name: MdmsRequest
+          in: body
+          description: Details for the new master data + RequestInfo meta data.
+          required: true
+          schema:
+            $ref: '#/definitions/MdmsRequest'
+      responses:
+        '202':
+          description: ResponseInfo with master data accepted for creation.
+          schema:
+            $ref: '#/definitions/MdmsResponseV2'
+        '400':
+          description: Master data creation failed.
+          schema:
+            $ref: 'https://raw.githubusercontent.com/egovernments/egov-services/master/docs/common/contracts/v1-0-0.yml#/definitions/ErrorRes'
+      tags:
+        - MDMS V2
+  /v2/_search:
+    post:
+      summary: Search master data matching the given criteria.
+      description: |
+        1. Fetches master data matching MdmsCriteria (tenantId, ids, uniqueIdentifiers, schemaCode, filters, isActive).
+        2. Applies tenant-level fallback - if no matching data is found at the given tenantId, the search progressively falls back to parent (e.g. state-level) tenants.
+        3. Supports pagination via offset/limit.
+      parameters:
+        - name: MdmsCriteriaReqV2
+          in: body
+          description: RequestInfo meta data + MdmsCriteria to search master data by.
+          required: true
+          schema:
+            $ref: '#/definitions/MdmsCriteriaReqV2'
+      responses:
+        '200':
+          description: Master data retrieved successfully.
+          schema:
+            $ref: '#/definitions/MdmsResponseV2'
+        '400':
+          description: Invalid input.
+          schema:
+            $ref: 'https://raw.githubusercontent.com/egovernments/egov-services/master/docs/common/contracts/v1-1-1.yml#/definitions/ErrorRes'
+      tags:
+        - MDMS V2
+  /v2/_count:
+    post:
+      summary: Get the count of master data matching the given criteria.
+      description: |
+        1. Returns the total number of master data records matching the given MdmsCriteria, without fetching the records themselves.
+        2. Accepts the exact same request contract (MdmsCriteriaReqV2/MdmsCriteria) as /v2/_search, so a totalCount can be paired with a paginated /v2/_search call using identical criteria.
+        3. Applies the same tenant-level fallback resolution as /v2/_search, so both APIs resolve to the same tenant for identical criteria. offset/limit on the criteria are ignored for this API.
+      parameters:
+        - name: MdmsCriteriaReqV2
+          in: body
+          description: RequestInfo meta data + MdmsCriteria to count master data by.
+          required: true
+          schema:
+            $ref: '#/definitions/MdmsCriteriaReqV2'
+      responses:
+        '200':
+          description: Master data count retrieved successfully.
+          schema:
+            $ref: '#/definitions/MdmsCountResponseV2'
+        '400':
+          description: Invalid input.
+          schema:
+            $ref: 'https://raw.githubusercontent.com/egovernments/egov-services/master/docs/common/contracts/v1-1-1.yml#/definitions/ErrorRes'
+      tags:
+        - MDMS V2
+  /v2/_update/{schemaCode}:
+    post:
+      summary: Update existing master data for a given schema.
+      description: |
+        Updates an existing master data record against the JSON schema identified by schemaCode. The updated Mdms.data is re-validated against the registered schema.
+      parameters:
+        - name: schemaCode
+          in: path
+          description: Unique code of the schema definition the master data conforms to.
+          required: true
+          type: string
+        - name: MdmsRequest
+          in: body
+          description: Details of the master data to update + RequestInfo meta data.
+          required: true
+          schema:
+            $ref: '#/definitions/MdmsRequest'
+      responses:
+        '202':
+          description: ResponseInfo with master data accepted for update.
+          schema:
+            $ref: '#/definitions/MdmsResponseV2'
+        '400':
+          description: Master data update failed.
+          schema:
+            $ref: 'https://raw.githubusercontent.com/egovernments/egov-services/master/docs/common/contracts/v1-0-0.yml#/definitions/ErrorRes'
+      tags:
+        - MDMS V2
+
+definitions:
+  Mdms:
+    type: object
+    description: A single master data record, validated against a registered JSON schema.
+    properties:
+      id:
+        type: string
+        description: Unique identifier (UUID) of the master data record.
+        minLength: 2
+        maxLength: 64
+        readOnly: true
+      tenantId:
+        type: string
+        description: Unique Identifier of ULB/tenant the master data belongs to.
+        minLength: 2
+        maxLength: 128
+      schemaCode:
+        type: string
+        description: Code of the schema definition this master data conforms to (e.g. 'common-masters.Department').
+        minLength: 2
+        maxLength: 128
+      uniqueIdentifier:
+        type: string
+        description: Business unique identifier for the record, unique within a schemaCode + tenantId.
+        minLength: 1
+        maxLength: 128
+      data:
+        type: object
+        description: The actual master data payload, validated against the schema identified by schemaCode.
+      isActive:
+        type: boolean
+        description: Denotes whether the master data record is active.
+        default: true
+      auditDetails:
+        $ref: 'https://raw.githubusercontent.com/egovernments/egov-services/master/docs/common/contracts/v1-0-0.yml#/definitions/AuditDetails'
+    required:
+      - tenantId
+      - schemaCode
+      - data
+
+  MdmsRequest:
+    type: object
+    description: Contract class to receive create/update requests for a single Mdms record.
+    properties:
+      RequestInfo:
+        $ref: 'https://raw.githubusercontent.com/egovernments/egov-services/master/docs/common/contracts/v1-1-1.yml#/definitions/RequestInfo'
+      Mdms:
+        $ref: '#/definitions/Mdms'
+    required:
+      - Mdms
+
+  MdmsCriteria:
+    type: object
+    description: Search/count criteria for master data. offset and limit are only honoured by /v2/_search.
+    properties:
+      tenantId:
+        type: string
+        description: Unique Identifier of ULB/tenant to search/count master data for. Falls back to parent tenants if no match is found.
+        minLength: 1
+        maxLength: 100
+      ids:
+        type: array
+        description: List of master data ids to filter by.
+        items:
+          type: string
+      uniqueIdentifiers:
+        type: array
+        description: List of business unique identifiers to filter by.
+        items:
+          type: string
+          minLength: 1
+          maxLength: 64
+      schemaCode:
+        type: string
+        description: Schema code to filter master data by (e.g. 'common-masters.Department').
+      filters:
+        type: object
+        description: Key-value filters applied against the JSON data payload (JSONB containment match).
+        additionalProperties:
+          type: string
+      isActive:
+        type: boolean
+        description: Filter master data by active/inactive status.
+      offset:
+        type: integer
+        description: Number of records to skip. Ignored by /v2/_count.
+      limit:
+        type: integer
+        description: Maximum number of records to return. Ignored by /v2/_count.
+    required:
+      - tenantId
+
+  MdmsCriteriaReqV2:
+    type: object
+    description: Contract class to receive search/count requests, shared unchanged between /v2/_search and /v2/_count.
+    properties:
+      RequestInfo:
+        $ref: 'https://raw.githubusercontent.com/egovernments/egov-services/master/docs/common/contracts/v1-1-1.yml#/definitions/RequestInfo'
+      MdmsCriteria:
+        $ref: '#/definitions/MdmsCriteria'
+    required:
+      - MdmsCriteria
+
+  MdmsResponseV2:
+    type: object
+    description: Contract class to send the response for create, search and update.
+    properties:
+      ResponseInfo:
+        $ref: 'https://raw.githubusercontent.com/egovernments/egov-services/master/docs/common/contracts/v1-0-0.yml#/definitions/ResponseInfo'
+      mdms:
+        type: array
+        description: List of master data records.
+        items:
+          $ref: '#/definitions/Mdms'
+
+  MdmsCountResponseV2:
+    type: object
+    description: Contract class to send the response for /v2/_count.
+    properties:
+      ResponseInfo:
+        $ref: 'https://raw.githubusercontent.com/egovernments/egov-services/master/docs/common/contracts/v1-0-0.yml#/definitions/ResponseInfo'
+      totalCount:
+        type: integer
+        format: int64
+        description: Total number of master data records matching the given MdmsCriteria.

--- a/core-services/mdms-v2/README.md
+++ b/core-services/mdms-v2/README.md
@@ -14,7 +14,7 @@ Master Data Management Service is a core service that is made available on the D
 Please refer to the  below Swagger API contarct for MDMS service to understand the structure of APIs and to have visualization of all internal APIs.
 http://editor.swagger.io/?url=https://raw.githubusercontent.com/egovernments/egov-services/master/docs/mdms/contract/v1-0-0.yml#!/
 
-For the MDMS V2 APIs (`/mdms-v2/v2/_search`, `_count`, `_create`, `_update`), refer to the contract checked into this repo:
+For the MDMS V2 APIs (schema `/mdms-v2/schema/v1/_create`, `_search`, `_update` and master data `/mdms-v2/v2/_search`, `_count`, `_create`, `_update`), refer to the contract checked into this repo:
 [`core-services/docs/mdms-v2-contract.yml`](../docs/mdms-v2-contract.yml). It can be pasted into http://editor.swagger.io/ for a visual walkthrough of the requests/responses.
 
 

--- a/core-services/mdms-v2/README.md
+++ b/core-services/mdms-v2/README.md
@@ -14,6 +14,9 @@ Master Data Management Service is a core service that is made available on the D
 Please refer to the  below Swagger API contarct for MDMS service to understand the structure of APIs and to have visualization of all internal APIs.
 http://editor.swagger.io/?url=https://raw.githubusercontent.com/egovernments/egov-services/master/docs/mdms/contract/v1-0-0.yml#!/
 
+For the MDMS V2 APIs (`/mdms-v2/v2/_search`, `_count`, `_create`, `_update`), refer to the contract checked into this repo:
+[`core-services/docs/mdms-v2-contract.yml`](../docs/mdms-v2-contract.yml). It can be pasted into http://editor.swagger.io/ for a visual walkthrough of the requests/responses.
+
 
 ## Service Details
 
@@ -77,6 +80,50 @@ This method fetches a list of masters for a specified module and tenantId.
     | Input Field                               | Description                                                       | Mandatory  |   Data Type      |
     | ----------------------------------------- | ------------------------------------------------------------------| -----------|------------------|
     | `mdms`                                    | Array of modules                                                  | Yes        | String           |
+
+### MDMS V2 API Details
+
+`BasePath` /mdms-v2/v2/[API endpoint]
+
+Full contract: [`core-services/docs/mdms-v2-contract.yml`](../docs/mdms-v2-contract.yml)
+
+##### Method
+a) `POST /_search`
+
+Fetches master data matching a `MdmsCriteria` (with tenant-level fallback and offset/limit pagination). Request: `MdmsCriteriaReqV2` (RequestInfo + MdmsCriteria). Response: `MdmsResponseV2` (ResponseInfo + list of `mdms`).
+
+b) `POST /_count`
+
+Returns the total number of master data records matching a `MdmsCriteria`, without fetching the records. It accepts **the exact same request contract as `/_search`** (`MdmsCriteriaReqV2`/`MdmsCriteria`) — offset/limit are ignored — and resolves the tenant-fallback chain identically to `/_search`, so the returned `totalCount` always corresponds to the same tenant tier that `/_search` would return data from for the same criteria.
+
+- `MdmsCriteriaReqV2` : RequestInfo + MdmsCriteria (same model used by `/_search`)
+
+- `MdmsCriteria`
+
+    | Input Field                               | Description                                                                    | Mandatory  |   Data Type            |
+    | ----------------------------------------- | -------------------------------------------------------------------------------| -----------|------------------------|
+    | `tenantId`                                | Unique id for a tenant. Falls back to parent tenants if no match is found.     | Yes        | String                 |
+    | `ids`                                     | List of master data ids to filter by.                                          | No         | Set of String          |
+    | `uniqueIdentifiers`                       | List of business unique identifiers to filter by.                              | No         | Set of String          |
+    | `schemaCode`                              | Schema code to filter master data by.                                          | No         | String                 |
+    | `filters`                                 | Key-value filters applied against the JSON data payload.                       | No         | Map of String to String|
+    | `isActive`                                | Filter master data by active/inactive status.                                  | No         | Boolean                |
+    | `offset`                                  | Number of records to skip. Ignored by `/_count`.                               | No         | Integer                |
+    | `limit`                                   | Maximum number of records to return. Ignored by `/_count`.                     | No         | Integer                |
+
+- `MdmsCountResponseV2` : ResponseInfo + totalCount
+
+    | Input Field                               | Description                                                       | Mandatory  |   Data Type      |
+    | ----------------------------------------- | ------------------------------------------------------------------| -----------|------------------|
+    | `totalCount`                              | Total number of master data records matching the given criteria.  | Yes        | Long             |
+
+c) `POST /_create/{schemaCode}`
+
+Creates a new master data record, validated against the JSON schema identified by `schemaCode`. Request/Response: `MdmsRequest` / `MdmsResponseV2`.
+
+d) `POST /_update/{schemaCode}`
+
+Updates an existing master data record, re-validated against the JSON schema identified by `schemaCode`. Request/Response: `MdmsRequest` / `MdmsResponseV2`.
 
 ### Kafka Consumers
 

--- a/core-services/mdms-v2/README.md
+++ b/core-services/mdms-v2/README.md
@@ -94,7 +94,7 @@ flag is `true` in [mdms-masters-config.json](https://raw.githubusercontent.com/e
 
 `BasePath` /mdms/v1/[API endpoint]
 
-##### Method
+#### Method
 a) `POST /_search`
 
 This method fetches a list of masters for a specified module and tenantId.
@@ -121,7 +121,7 @@ This method fetches a list of masters for a specified module and tenantId.
 
 Full contract: [`core-services/docs/mdms-v2-contract.yml`](../docs/mdms-v2-contract.yml)
 
-##### Method
+#### Method
 a) `POST /_search`
 
 Fetches master data matching a `MdmsCriteria` (with tenant-level fallback and offset/limit pagination). Request: `MdmsCriteriaReqV2` (RequestInfo + MdmsCriteria). Response: `MdmsResponseV2` (ResponseInfo + list of `mdms`).

--- a/core-services/mdms-v2/README.md
+++ b/core-services/mdms-v2/README.md
@@ -4,7 +4,41 @@ Master Data Management Service is a core service that is made available on the D
 
 ### DB UML Diagram
 
-- NA
+MDMS V2 persists to two Postgres tables (see `src/main/resources/db/migration/main/`). There is no enforced foreign key between them - `eg_mdms_data.schemacode` is only logically validated against `eg_mdms_schema_definition.code` at the application layer (schema validation on create/update), not via a DB constraint.
+
+```mermaid
+erDiagram
+    EG_MDMS_SCHEMA_DEFINITION {
+        varchar_64 id "NOT NULL"
+        varchar_255 tenantid PK "NOT NULL"
+        varchar_255 code PK "NOT NULL"
+        varchar_512 description
+        jsonb definition "NOT NULL"
+        boolean isactive "NOT NULL"
+        varchar_64 createdby
+        varchar_64 lastmodifiedby
+        bigint createdtime
+        bigint lastmodifiedtime
+    }
+
+    EG_MDMS_DATA {
+        varchar_64 id UK "NOT NULL"
+        varchar_255 tenantid PK "NOT NULL"
+        varchar_255 schemacode PK "NOT NULL"
+        varchar_255 uniqueidentifier PK "NOT NULL"
+        jsonb data "NOT NULL"
+        boolean isactive "NOT NULL"
+        varchar_64 createdby
+        varchar_64 lastmodifiedby
+        bigint createdtime
+        bigint lastmodifiedtime
+    }
+
+    EG_MDMS_SCHEMA_DEFINITION ||--o{ EG_MDMS_DATA : "validates data against (schemacode = code, app-level only)"
+```
+
+- `eg_mdms_schema_definition` - one row per registered JSON schema, keyed by `(tenantid, code)`. `definition` holds the JSON schema used to validate master data.
+- `eg_mdms_data` - one row per master data record, keyed by `(tenantid, schemacode, uniqueidentifier)`, with a separate unique `id` (UUID) used as the external identifier in `/v2/_update/{schemaCode}` requests. `data` holds the actual master data payload.
 
 ### Service Dependencies
 - NA

--- a/core-services/mdms-v2/src/main/java/org/egov/infra/mdms/controller/MDMSControllerV2.java
+++ b/core-services/mdms-v2/src/main/java/org/egov/infra/mdms/controller/MDMSControllerV2.java
@@ -54,7 +54,7 @@ public class MDMSControllerV2 {
      */
     @RequestMapping(value="_count", method = RequestMethod.POST)
     public ResponseEntity<MdmsCountResponseV2> count(@Valid @RequestBody MdmsCriteriaReqV2 masterDataSearchCriteria) {
-        Integer totalCount = mdmsServiceV2.count(masterDataSearchCriteria);
+        Long totalCount = mdmsServiceV2.count(masterDataSearchCriteria);
         return new ResponseEntity<>(ResponseUtil.getMasterDataV2CountResponse(RequestInfo.builder().build(), totalCount), HttpStatus.OK);
     }
 

--- a/core-services/mdms-v2/src/main/java/org/egov/infra/mdms/controller/MDMSControllerV2.java
+++ b/core-services/mdms-v2/src/main/java/org/egov/infra/mdms/controller/MDMSControllerV2.java
@@ -48,6 +48,17 @@ public class MDMSControllerV2 {
     }
 
     /**
+     * Request handler for serving count requests, using the same criteria model as search
+     * @param masterDataSearchCriteria
+     * @return
+     */
+    @RequestMapping(value="_count", method = RequestMethod.POST)
+    public ResponseEntity<MdmsCountResponseV2> count(@Valid @RequestBody MdmsCriteriaReqV2 masterDataSearchCriteria) {
+        Integer totalCount = mdmsServiceV2.count(masterDataSearchCriteria);
+        return new ResponseEntity<>(ResponseUtil.getMasterDataV2CountResponse(RequestInfo.builder().build(), totalCount), HttpStatus.OK);
+    }
+
+    /**
      * Request handler for serving update requests
      * @param mdmsRequest
      * @param schemaCode

--- a/core-services/mdms-v2/src/main/java/org/egov/infra/mdms/model/MdmsCountResponseV2.java
+++ b/core-services/mdms-v2/src/main/java/org/egov/infra/mdms/model/MdmsCountResponseV2.java
@@ -1,0 +1,24 @@
+package org.egov.infra.mdms.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.egov.common.contract.response.ResponseInfo;
+
+import jakarta.validation.Valid;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MdmsCountResponseV2 {
+
+    @JsonProperty("ResponseInfo")
+    @Valid
+    private ResponseInfo responseInfo = null;
+
+    @JsonProperty("totalCount")
+    private Integer totalCount = null;
+}

--- a/core-services/mdms-v2/src/main/java/org/egov/infra/mdms/model/MdmsCountResponseV2.java
+++ b/core-services/mdms-v2/src/main/java/org/egov/infra/mdms/model/MdmsCountResponseV2.java
@@ -20,5 +20,5 @@ public class MdmsCountResponseV2 {
     private ResponseInfo responseInfo = null;
 
     @JsonProperty("totalCount")
-    private Integer totalCount = null;
+    private Long totalCount = null;
 }

--- a/core-services/mdms-v2/src/main/java/org/egov/infra/mdms/repository/MdmsDataRepository.java
+++ b/core-services/mdms-v2/src/main/java/org/egov/infra/mdms/repository/MdmsDataRepository.java
@@ -15,5 +15,7 @@ public interface MdmsDataRepository {
 
     public  List<Mdms> searchV2(MdmsCriteriaV2 mdmsCriteriaV2);
 
+    public Integer countV2(MdmsCriteriaV2 mdmsCriteriaV2);
+
     public Map<String, Map<String, JSONArray>> search(MdmsCriteria mdmsCriteria);
 }

--- a/core-services/mdms-v2/src/main/java/org/egov/infra/mdms/repository/MdmsDataRepository.java
+++ b/core-services/mdms-v2/src/main/java/org/egov/infra/mdms/repository/MdmsDataRepository.java
@@ -15,7 +15,7 @@ public interface MdmsDataRepository {
 
     public  List<Mdms> searchV2(MdmsCriteriaV2 mdmsCriteriaV2);
 
-    public Integer countV2(MdmsCriteriaV2 mdmsCriteriaV2);
+    public Long countV2(MdmsCriteriaV2 mdmsCriteriaV2);
 
     public Map<String, Map<String, JSONArray>> search(MdmsCriteria mdmsCriteria);
 }

--- a/core-services/mdms-v2/src/main/java/org/egov/infra/mdms/repository/impl/MdmsDataRepositoryImpl.java
+++ b/core-services/mdms-v2/src/main/java/org/egov/infra/mdms/repository/impl/MdmsDataRepositoryImpl.java
@@ -81,11 +81,11 @@ public class MdmsDataRepositoryImpl implements MdmsDataRepository {
      * @return
      */
     @Override
-    public Integer countV2(MdmsCriteriaV2 mdmsCriteriaV2) {
+    public Long countV2(MdmsCriteriaV2 mdmsCriteriaV2) {
         List<Object> preparedStmtList = new ArrayList<>();
         String query = mdmsDataQueryBuilderV2.getMdmsDataCountQuery(mdmsCriteriaV2, preparedStmtList);
         log.info(query);
-        return jdbcTemplate.queryForObject(query, preparedStmtList.toArray(), Integer.class);
+        return jdbcTemplate.queryForObject(query, preparedStmtList.toArray(), Long.class);
     }
 
     /**

--- a/core-services/mdms-v2/src/main/java/org/egov/infra/mdms/repository/impl/MdmsDataRepositoryImpl.java
+++ b/core-services/mdms-v2/src/main/java/org/egov/infra/mdms/repository/impl/MdmsDataRepositoryImpl.java
@@ -77,6 +77,18 @@ public class MdmsDataRepositoryImpl implements MdmsDataRepository {
     }
 
     /**
+     * @param mdmsCriteriaV2
+     * @return
+     */
+    @Override
+    public Integer countV2(MdmsCriteriaV2 mdmsCriteriaV2) {
+        List<Object> preparedStmtList = new ArrayList<>();
+        String query = mdmsDataQueryBuilderV2.getMdmsDataCountQuery(mdmsCriteriaV2, preparedStmtList);
+        log.info(query);
+        return jdbcTemplate.queryForObject(query, preparedStmtList.toArray(), Integer.class);
+    }
+
+    /**
      * @param mdmsCriteria
      * @return
      */

--- a/core-services/mdms-v2/src/main/java/org/egov/infra/mdms/repository/querybuilder/MdmsDataQueryBuilderV2.java
+++ b/core-services/mdms-v2/src/main/java/org/egov/infra/mdms/repository/querybuilder/MdmsDataQueryBuilderV2.java
@@ -19,6 +19,8 @@ public class MdmsDataQueryBuilderV2 {
     private static final String SEARCH_MDMS_DATA_QUERY = "SELECT data.id, data.tenantid, data.uniqueidentifier, data.schemacode, data.data, data.isactive, data.createdby, data.lastmodifiedby, data.createdtime, data.lastmodifiedtime" +
             " FROM eg_mdms_data data ";
 
+    private static final String COUNT_MDMS_DATA_QUERY = "SELECT COUNT(*) FROM eg_mdms_data data ";
+
     private static final String MDMS_DATA_QUERY_ORDER_BY_CLAUSE = " order by data.createdtime desc ";
 
     /**
@@ -28,20 +30,32 @@ public class MdmsDataQueryBuilderV2 {
      * @return
      */
     public String getMdmsDataSearchQuery(MdmsCriteriaV2 mdmsCriteriaV2, List<Object> preparedStmtList) {
-        String query = buildQuery(mdmsCriteriaV2, preparedStmtList);
+        String query = buildQuery(mdmsCriteriaV2, preparedStmtList, SEARCH_MDMS_DATA_QUERY);
         query = QueryUtil.addOrderByClause(query, MDMS_DATA_QUERY_ORDER_BY_CLAUSE);
         query = getPaginatedQuery(query, mdmsCriteriaV2, preparedStmtList);
         return query;
     }
 
     /**
-     * Method to build query dynamically based on the criteria passed to the method
+     * Method to handle request for fetching MDMS data count query, built using the same
+     * criteria (and hence the same WHERE clause) as the search query.
      * @param mdmsCriteriaV2
      * @param preparedStmtList
      * @return
      */
-    private String buildQuery(MdmsCriteriaV2 mdmsCriteriaV2, List<Object> preparedStmtList) {
-        StringBuilder builder = new StringBuilder(SEARCH_MDMS_DATA_QUERY);
+    public String getMdmsDataCountQuery(MdmsCriteriaV2 mdmsCriteriaV2, List<Object> preparedStmtList) {
+        return buildQuery(mdmsCriteriaV2, preparedStmtList, COUNT_MDMS_DATA_QUERY);
+    }
+
+    /**
+     * Method to build query dynamically based on the criteria passed to the method
+     * @param mdmsCriteriaV2
+     * @param preparedStmtList
+     * @param baseQuery
+     * @return
+     */
+    private String buildQuery(MdmsCriteriaV2 mdmsCriteriaV2, List<Object> preparedStmtList, String baseQuery) {
+        StringBuilder builder = new StringBuilder(baseQuery);
         Map<String, String> schemaCodeFilterMap = mdmsCriteriaV2.getSchemaCodeFilterMap();
         if (!Objects.isNull(mdmsCriteriaV2.getTenantId())) {
             QueryUtil.addClauseIfRequired(builder, preparedStmtList);

--- a/core-services/mdms-v2/src/main/java/org/egov/infra/mdms/service/MDMSServiceV2.java
+++ b/core-services/mdms-v2/src/main/java/org/egov/infra/mdms/service/MDMSServiceV2.java
@@ -81,7 +81,7 @@ public class MDMSServiceV2 {
      * @param mdmsCriteriaReqV2
      * @return
      */
-    public Integer count(MdmsCriteriaReqV2 mdmsCriteriaReqV2) {
+    public Long count(MdmsCriteriaReqV2 mdmsCriteriaReqV2) {
         return resolveFallbackTenant(mdmsCriteriaReqV2.getMdmsCriteria());
     }
 
@@ -92,10 +92,10 @@ public class MDMSServiceV2 {
      * @param mdmsCriteriaV2
      * @return the count of master data at the resolved tenant level
      */
-    private Integer resolveFallbackTenant(MdmsCriteriaV2 mdmsCriteriaV2) {
+    private Long resolveFallbackTenant(MdmsCriteriaV2 mdmsCriteriaV2) {
         List<String> subTenantListForFallback = FallbackUtil.getSubTenantListForFallBack(mdmsCriteriaV2.getTenantId());
 
-        Integer count = 0;
+        Long count = 0L;
         for (String subTenantId : subTenantListForFallback) {
             mdmsCriteriaV2.setTenantId(subTenantId);
             count = mdmsDataRepository.countV2(mdmsCriteriaV2);

--- a/core-services/mdms-v2/src/main/java/org/egov/infra/mdms/service/MDMSServiceV2.java
+++ b/core-services/mdms-v2/src/main/java/org/egov/infra/mdms/service/MDMSServiceV2.java
@@ -11,9 +11,7 @@ import org.egov.infra.mdms.utils.SchemaUtil;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.util.CollectionUtils;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -70,25 +68,43 @@ public class MDMSServiceV2 {
      */
     public List<Mdms> search(MdmsCriteriaReqV2 mdmsCriteriaReqV2) {
 
-        /*
-         * Set incoming tenantId as state level tenantId for fallback in case master data for
-         * concrete tenantId does not exist.
-         */
-        String tenantId = mdmsCriteriaReqV2.getMdmsCriteria().getTenantId();
+        // Resolve the tenant level (concrete tenant or a fallback ancestor) that actually
+        // has matching master data, so search results and count() agree on the same tenant.
+        resolveFallbackTenant(mdmsCriteriaReqV2.getMdmsCriteria());
 
-        List<Mdms> masterDataList = new ArrayList<>();
-        List<String> subTenantListForFallback = FallbackUtil.getSubTenantListForFallBack(tenantId);
+        return mdmsDataRepository.searchV2(mdmsCriteriaReqV2.getMdmsCriteria());
+    }
 
-        // Make a call to repository and get list of master data
-        for(String subTenantId : subTenantListForFallback) {
-            mdmsCriteriaReqV2.getMdmsCriteria().setTenantId(subTenantId);
-            masterDataList = mdmsDataRepository.searchV2(mdmsCriteriaReqV2.getMdmsCriteria());
+    /**
+     * This method processes the requests that come for master data count, using the same
+     * criteria model (MdmsCriteriaReqV2) as search.
+     * @param mdmsCriteriaReqV2
+     * @return
+     */
+    public Integer count(MdmsCriteriaReqV2 mdmsCriteriaReqV2) {
+        return resolveFallbackTenant(mdmsCriteriaReqV2.getMdmsCriteria());
+    }
 
-            if(!CollectionUtils.isEmpty(masterDataList))
+    /**
+     * Walks the tenant fallback chain (concrete tenantId up to state level) and mutates
+     * mdmsCriteriaV2's tenantId to the first level that has matching master data, so that
+     * search() and count() resolve to the exact same tenant for identical criteria.
+     * @param mdmsCriteriaV2
+     * @return the count of master data at the resolved tenant level
+     */
+    private Integer resolveFallbackTenant(MdmsCriteriaV2 mdmsCriteriaV2) {
+        List<String> subTenantListForFallback = FallbackUtil.getSubTenantListForFallBack(mdmsCriteriaV2.getTenantId());
+
+        Integer count = 0;
+        for (String subTenantId : subTenantListForFallback) {
+            mdmsCriteriaV2.setTenantId(subTenantId);
+            count = mdmsDataRepository.countV2(mdmsCriteriaV2);
+
+            if (count > 0)
                 break;
         }
 
-        return masterDataList;
+        return count;
     }
 
     /**

--- a/core-services/mdms-v2/src/main/java/org/egov/infra/mdms/utils/ResponseUtil.java
+++ b/core-services/mdms-v2/src/main/java/org/egov/infra/mdms/utils/ResponseUtil.java
@@ -4,6 +4,7 @@ import org.egov.common.contract.request.RequestInfo;
 import org.egov.common.contract.response.ResponseInfo;
 import org.egov.common.utils.ResponseInfoUtil;
 import org.egov.infra.mdms.model.Mdms;
+import org.egov.infra.mdms.model.MdmsCountResponseV2;
 import org.egov.infra.mdms.model.MdmsResponseV2;
 import org.egov.infra.mdms.model.SchemaDefinition;
 import org.egov.infra.mdms.model.SchemaDefinitionResponse;
@@ -23,6 +24,12 @@ public class ResponseUtil {
     public static MdmsResponseV2 getMasterDataV2Response(RequestInfo requestInfo, List<Mdms> masterDataList){
         ResponseInfo responseInfo = ResponseInfoUtil.createResponseInfoFromRequestInfo(requestInfo, Boolean.TRUE);
         MdmsResponseV2 response = MdmsResponseV2.builder().mdms(masterDataList).responseInfo(responseInfo).build();
+        return response;
+    }
+
+    public static MdmsCountResponseV2 getMasterDataV2CountResponse(RequestInfo requestInfo, Integer totalCount){
+        ResponseInfo responseInfo = ResponseInfoUtil.createResponseInfoFromRequestInfo(requestInfo, Boolean.TRUE);
+        MdmsCountResponseV2 response = MdmsCountResponseV2.builder().totalCount(totalCount).responseInfo(responseInfo).build();
         return response;
     }
 

--- a/core-services/mdms-v2/src/main/java/org/egov/infra/mdms/utils/ResponseUtil.java
+++ b/core-services/mdms-v2/src/main/java/org/egov/infra/mdms/utils/ResponseUtil.java
@@ -27,7 +27,7 @@ public class ResponseUtil {
         return response;
     }
 
-    public static MdmsCountResponseV2 getMasterDataV2CountResponse(RequestInfo requestInfo, Integer totalCount){
+    public static MdmsCountResponseV2 getMasterDataV2CountResponse(RequestInfo requestInfo, Long totalCount){
         ResponseInfo responseInfo = ResponseInfoUtil.createResponseInfoFromRequestInfo(requestInfo, Boolean.TRUE);
         MdmsCountResponseV2 response = MdmsCountResponseV2.builder().totalCount(totalCount).responseInfo(responseInfo).build();
         return response;


### PR DESCRIPTION
## Summary
- Adds `POST /v2/_count` to the mdms-v2 service, reusing the same `MdmsCriteriaReqV2`/`MdmsCriteriaV2` request models as `POST /v2/_search`.
- Refactors `MdmsDataQueryBuilderV2` to share its criteria-driven WHERE-clause building between the search query and a new `SELECT COUNT(*) ...` count query.
- Unifies the tenant-fallback resolution used by `search()` and `count()` in `MDMSServiceV2` so both agree on the same tenant tier for identical criteria (previously `count()`'s unpaginated existence check could resolve to a different tenant than `search()`'s paginated result check).

## Test plan
- [x] `mvn compile` passes for the `mdms-v2` module
- [ ] Manually call `POST /v2/_search` and `POST /v2/_count` with the same `MdmsCriteriaReqV2` body and confirm `totalCount` matches the number of records returned across pagination
- [ ] Verify tenant-fallback behavior (e.g. state-level fallback) returns a consistent tenant for both endpoints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an MDMS V2 count endpoint that returns the number of records matching search criteria.
  * Count responses include standard response metadata and the total matching record count.
  * Tenant fallback selection now aligns with available matching data, improving consistency between counts and search results.

* **Documentation**
  * Added API documentation for MDMS V2 create, search, count, and update operations, including request and response schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->