### PR TITLE
fix: handle non-array x-ref-schema in mdms validation

### DIFF
--- a/core-services/mdms-v2/src/main/java/org/egov/infra/mdms/service/validator/MdmsDataValidator.java
+++ b/core-services/mdms-v2/src/main/java/org/egov/infra/mdms/service/validator/MdmsDataValidator.java
@@ -137,9 +137,15 @@ public class MdmsDataValidator {
      */
     private void validateReference(JSONObject schemaObject, Mdms mdms) {
         if (schemaObject.has(X_REFERENCE_SCHEMA_KEY)) {
-            org.json.JSONArray referenceSchema = (org.json.JSONArray) schemaObject.get(X_REFERENCE_SCHEMA_KEY);
+            Object referenceSchemaObject = schemaObject.get(X_REFERENCE_SCHEMA_KEY);
 
-            if (referenceSchema != null && referenceSchema.length() > 0) {
+            if (!(referenceSchemaObject instanceof org.json.JSONArray)) {
+                return;
+            }
+
+            org.json.JSONArray referenceSchema = (org.json.JSONArray) referenceSchemaObject;
+
+            if (referenceSchema.length() > 0) {
                 JsonNode mdmsData = mdms.getData();
 
                 IntStream.range(0, referenceSchema.length()).forEach(i -> {


### PR DESCRIPTION
## Description

Fixes a `ClassCastException` in MDMS reference validation when
`x-ref-schema` is present but is not a JSON array.

## Root Cause

The `validateReference()` method previously cast `x-ref-schema`
directly to `org.json.JSONArray`. When `x-ref-schema` contains
an empty object (`{}`), this causes a `ClassCastException`.

## Changes

- Added type checking before casting `x-ref-schema`
- Safely ignores non-array `x-ref-schema` values
- Preserved existing reference validation for valid JSON arrays
- Prevented the MDMS validation flow from failing with `ClassCastException`

## Testing

- Built the Core Services modules successfully with Maven
- Verified the project builds successfully with `BUILD SUCCESS`

## Related Issue

Closes #1372
<img width="1920" height="1080" alt="issue-1372-maven-build-success" src="https://github.com/user-attachments/assets/39e5378a-7054-4d6c-98f1-e56931060ca6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation handling for reference-schema values in MDMS data.
  * Non-array reference values are now safely ignored, while valid arrays continue to be validated as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->