### PR TITLE
feat(access-control): return ABAC policy metadata from MDMS actions

### DIFF
--- a/core-services/egov-accesscontrol/src/main/java/org/egov/access/domain/model/MdmsAction.java
+++ b/core-services/egov-accesscontrol/src/main/java/org/egov/access/domain/model/MdmsAction.java
@@ -1,0 +1,44 @@
+package org.egov.access.domain.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * An action projected from MDMS with optional, opaque policy metadata.
+ *
+ * <p>This type is intentionally limited to the {@code /v1/actions/mdms/_get} response path. The
+ * shared {@link Action} model remains the unchanged request and persistence contract for the
+ * database-backed action endpoints.
+ */
+public class MdmsAction extends Action {
+
+    private String method;
+    private Object resource;
+    private Object condition;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String getMethod() {
+        return method;
+    }
+
+    public void setMethod(String method) {
+        this.method = method;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Object getResource() {
+        return resource;
+    }
+
+    public void setResource(Object resource) {
+        this.resource = resource;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Object getCondition() {
+        return condition;
+    }
+
+    public void setCondition(Object condition) {
+        this.condition = condition;
+    }
+}

--- a/core-services/egov-accesscontrol/src/main/java/org/egov/access/persistence/repository/ActionRepository.java
+++ b/core-services/egov-accesscontrol/src/main/java/org/egov/access/persistence/repository/ActionRepository.java
@@ -45,12 +45,14 @@ import java.sql.Date;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
 import org.egov.access.domain.model.Action;
+import org.egov.access.domain.model.MdmsAction;
 import org.egov.access.persistence.repository.querybuilder.ActionQueryBuilder;
 import org.egov.access.persistence.repository.rowmapper.ActionSearchRowMapper;
 import org.egov.access.persistence.repository.rowmapper.ModuleSearchRowMapper;
@@ -65,6 +67,7 @@ import org.egov.mdms.model.MdmsCriteriaReq;
 import org.egov.mdms.model.ModuleDetail;
 import org.json.JSONArray;
 import org.json.JSONException;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -628,11 +631,11 @@ private void getMdmsActionCriteria(ActionRequest actionRequest, String actionFil
 	actionmcq.setMdmsCriteria(actionmc);
 }
 
-private List<Action> convertToAction(ActionRequest actionRequest,JSONArray actionsArray)
+List<Action> convertToAction(ActionRequest actionRequest,JSONArray actionsArray)
 		throws JSONException {
 	List<Action> actionList = new ArrayList<Action>();
 	for (int i = 0; i < actionsArray.length(); i++) {
-		Action act = new Action();
+		MdmsAction act = new MdmsAction();
 		if(actionsArray.getJSONObject(i).has("displayName")){
 		act.setDisplayName(actionsArray.getJSONObject(i).getString("displayName"));
 		} else {act.setDisplayName("");}
@@ -673,12 +676,41 @@ private List<Action> convertToAction(ActionRequest actionRequest,JSONArray actio
 		if(actionsArray.getJSONObject(i).has("rightIcon")){
 		act.setRightIcon(actionsArray.getJSONObject(i).getString("rightIcon"));
 		} else {act.setRightIcon("");}
+
+		JSONObject actionJson = actionsArray.getJSONObject(i);
+		if (actionJson.has("method") && !actionJson.isNull("method"))
+			act.setMethod(actionJson.getString("method"));
+		if (actionJson.has("resource") && !actionJson.isNull("resource"))
+			act.setResource(toPlainJsonValue(actionJson.get("resource")));
+		if (actionJson.has("condition") && !actionJson.isNull("condition"))
+			act.setCondition(toPlainJsonValue(actionJson.get("condition")));
 		
 		act.setTenantId(actionRequest.getTenantId());
 		actionList.add(act);
 	}
  
 	 return actionList;
+}
+
+private Object toPlainJsonValue(Object value) throws JSONException {
+	if (value instanceof JSONObject) {
+		JSONObject object = (JSONObject) value;
+		Map<String, Object> result = new LinkedHashMap<>();
+		Iterator<String> keys = object.keys();
+		while (keys.hasNext()) {
+			String key = keys.next();
+			result.put(key, toPlainJsonValue(object.get(key)));
+		}
+		return result;
+	}
+	if (value instanceof JSONArray) {
+		JSONArray array = (JSONArray) value;
+		List<Object> result = new ArrayList<>(array.length());
+		for (int i = 0; i < array.length(); i++)
+			result.add(toPlainJsonValue(array.get(i)));
+		return result;
+	}
+	return value == JSONObject.NULL ? null : value;
 }
     
 	public static RequestInfo getRInfo()

--- a/core-services/egov-accesscontrol/src/test/java/org/egov/access/persistence/repository/ActionMdmsProjectionTest.java
+++ b/core-services/egov-accesscontrol/src/test/java/org/egov/access/persistence/repository/ActionMdmsProjectionTest.java
@@ -1,0 +1,111 @@
+package org.egov.access.persistence.repository;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.egov.access.domain.model.Action;
+import org.egov.access.domain.model.MdmsAction;
+import org.egov.access.web.contract.action.ActionRequest;
+import org.egov.access.web.contract.action.ActionSearchResponse;
+import org.json.JSONArray;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ActionMdmsProjectionTest {
+
+    private final ActionRepository repository = new ActionRepository();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    public void projectsAndSerializesOpaquePolicyMetadataWithoutChangingItsJsonShape() throws Exception {
+        JSONArray mdmsActions = new JSONArray("["
+                + "{\"id\":2008,\"url\":\"/pgr-services/v2/request/_search\","
+                + "\"method\":\"POST\","
+                + "\"resource\":{\"complaint\":{\"attributes\":[\"citizen.mobileNumber\"]}},"
+                + "\"condition\":{\"and\":[{\"==\":[{\"var\":\"user.tenantId\"},\"pg\"]},true]}},"
+                + "{\"id\":2009,\"url\":\"/pgr-services/v2/request/_count\","
+                + "\"method\":\"POST\",\"resource\":[\"complaint\"],\"condition\":false}"
+                + "]");
+
+        List<Action> actions = repository.convertToAction(requestFor("pg.citya"), mdmsActions);
+
+        assertThat(actions).hasSize(2);
+        assertThat(actions).allSatisfy(action -> assertThat(action).isInstanceOf(MdmsAction.class));
+        MdmsAction searchAction = (MdmsAction) actions.get(0);
+        MdmsAction countAction = (MdmsAction) actions.get(1);
+        assertThat(searchAction.getMethod()).isEqualTo("POST");
+        assertThat(searchAction.getResource()).isInstanceOf(Map.class);
+        assertThat(searchAction.getCondition()).isInstanceOf(Map.class);
+        assertThat(countAction.getResource()).isEqualTo(List.of("complaint"));
+        assertThat(countAction.getCondition()).isEqualTo(false);
+        assertThat(actions).allSatisfy(action -> assertThat(action.getTenantId()).isEqualTo("pg.citya"));
+
+        ActionSearchResponse response = new ActionSearchResponse();
+        response.setActions(actions);
+        JsonNode json = objectMapper.readTree(objectMapper.writeValueAsString(response));
+
+        assertThat(json.at("/actions/0/method").asText()).isEqualTo("POST");
+        assertThat(json.at("/actions/0/resource/complaint/attributes/0").asText())
+                .isEqualTo("citizen.mobileNumber");
+        assertThat(json.at("/actions/0/condition/and/0/==/0/var").asText())
+                .isEqualTo("user.tenantId");
+        assertThat(json.at("/actions/1/resource").isArray()).isTrue();
+        assertThat(json.at("/actions/1/condition").isBoolean()).isTrue();
+        assertThat(json.at("/actions/1/condition").asBoolean()).isFalse();
+    }
+
+    @Test
+    public void leavesPolicyMetadataNullForLegacyMdmsActions() throws Exception {
+        JSONArray mdmsActions = new JSONArray("[{\"id\":1,\"url\":\"/legacy\"}]");
+
+        Action action = repository.convertToAction(requestFor("pg"), mdmsActions).get(0);
+
+        assertThat(action).isInstanceOf(MdmsAction.class);
+        MdmsAction mdmsAction = (MdmsAction) action;
+        assertThat(mdmsAction.getMethod()).isNull();
+        assertThat(mdmsAction.getResource()).isNull();
+        assertThat(mdmsAction.getCondition()).isNull();
+        assertThat(action.getDisplayName()).isEmpty();
+        assertThat(action.isEnabled()).isFalse();
+
+        ActionSearchResponse response = new ActionSearchResponse();
+        response.setActions(List.of(action));
+        JsonNode wireAction = objectMapper.readTree(objectMapper.writeValueAsString(response)).at("/actions/0");
+        assertThat(wireAction.has("method")).isFalse();
+        assertThat(wireAction.has("resource")).isFalse();
+        assertThat(wireAction.has("condition")).isFalse();
+    }
+
+    @Test
+    public void sharedActionKeepsItsExistingDatabaseAndWireContract() throws Exception {
+        Action action = Action.builder()
+                .id(1L)
+                .name("Legacy DB action")
+                .url("/legacy")
+                .enabled(true)
+                .build();
+
+        JsonNode wireAction = objectMapper.readTree(objectMapper.writeValueAsString(action));
+
+        assertThat(wireAction.get("id").asLong()).isEqualTo(1L);
+        assertThat(wireAction.get("name").asText()).isEqualTo("Legacy DB action");
+        assertThat(wireAction.get("url").asText()).isEqualTo("/legacy");
+        assertThat(wireAction.get("enabled").asBoolean()).isTrue();
+        List<String> fieldNames = new ArrayList<>();
+        wireAction.fieldNames().forEachRemaining(fieldNames::add);
+        assertThat(fieldNames).containsExactlyInAnyOrder(
+                "id", "name", "url", "displayName", "orderNumber", "queryParams",
+                "parentModule", "enabled", "serviceCode", "tenantId", "createdDate", "createdBy",
+                "lastModifiedDate", "lastModifiedBy", "path", "navigationURL", "leftIcon", "rightIcon");
+    }
+
+    private ActionRequest requestFor(String tenantId) {
+        ActionRequest request = new ActionRequest();
+        request.setTenantId(tenantId);
+        return request;
+    }
+}


### PR DESCRIPTION
## What

Project optional `method`, `resource`, and `condition` fields from `ACCESSCONTROL-ACTIONS-TEST.actions-test` through `/access/v1/actions/mdms/_get` without changing the legacy database-backed `Action` contract.

This is the access-control transport dependency for CCRS dashboard/PGR ABAC parity (CCRS#1050 / CCRS PR #1814): PGR asks egov-accesscontrol for the caller-visible action and consumes Vinoth's action-2008 policy instead of maintaining a dashboard-specific role engine.

## Why this shape

- Policy metadata remains opaque to the legacy action repository and is exposed only on the MDMS response path.
- Nested JSON objects/arrays/booleans keep their wire shape.
- Legacy actions omit all three optional fields, so current clients remain compatible.

## Validation

- `mvn -f core-services/egov-accesscontrol/pom.xml test`
- 3/3 `ActionMdmsProjectionTest` cases pass.

## Dependency

CCRS currently pins a feature image carrying equivalent Vinoth ABAC fields. Merging this gives the behavior a stable master lineage; CCRS can then replace the feature-image pin with a stable build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for MDMS actions with optional method, resource, and condition metadata.
  * Preserves nested policy metadata, including objects and arrays, during action responses.
  * Omits unavailable metadata fields from serialized responses.

* **Bug Fixes**
  * Maintains compatibility with legacy actions and existing action response formats.
  * Preserves tenant information when retrieving actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->