### PR TITLE
Fix OtpRequestTest compilation error after adding userName to Otp con…

### DIFF
--- a/core-services/user-otp/src/test/java/org/egov/web/contract/OtpRequestTest.java
+++ b/core-services/user-otp/src/test/java/org/egov/web/contract/OtpRequestTest.java
@@ -11,7 +11,7 @@ public class OtpRequestTest {
 
     @Test
     public void test_should_map_from_contract_to_domain() {
-        final Otp otp = new Otp("mobileNumber", "tenantId", "register", "CITIZEN", null);
+        final Otp otp = new Otp("mobileNumber", "tenantId", "register", "CITIZEN", null, null);
         final OtpRequest request = new OtpRequest(null, otp);
 
         final org.egov.domain.model.OtpRequest domainOtpRequest = request.toDomain();
@@ -24,7 +24,7 @@ public class OtpRequestTest {
 
 	@Test
 	public void test_should_set_request_type_to_register_when_type_not_explicitly_specified() {
-		final Otp otp = new Otp("mobileNumber", "tenantId", null, "CITIZEN", null);
+		final Otp otp = new Otp("mobileNumber", "tenantId", null, "CITIZEN", null, null);
 		final OtpRequest request = new OtpRequest(null, otp);
 
 		final org.egov.domain.model.OtpRequest domainOtpRequest = request.toDomain();
@@ -34,7 +34,7 @@ public class OtpRequestTest {
 
 	@Test
 	public void test_should_set_request_type_to_null_when_type_is_unknown() {
-		final Otp otp = new Otp("mobileNumber", "tenantId", "unknown", "CITIZEN", null);
+		final Otp otp = new Otp("mobileNumber", "tenantId", "unknown", "CITIZEN", null, null);
 		final OtpRequest request = new OtpRequest(null, otp);
 
 		final org.egov.domain.model.OtpRequest domainOtpRequest = request.toDomain();
@@ -44,7 +44,7 @@ public class OtpRequestTest {
 
 	@Test
 	public void test_should_set_request_type_to_register_when_type_is_register() {
-		final Otp otp = new Otp("mobileNumber", "tenantId", "regisTER", "CITIZEN", null);
+		final Otp otp = new Otp("mobileNumber", "tenantId", "regisTER", "CITIZEN", null, null);
 		final OtpRequest request = new OtpRequest(null, otp);
 
 		final org.egov.domain.model.OtpRequest domainOtpRequest = request.toDomain();
@@ -54,7 +54,7 @@ public class OtpRequestTest {
 
 	@Test
 	public void test_should_set_request_type_to_password_reset_when_type_is_passwordreset() {
-		final Otp otp = new Otp("mobileNumber", "tenantId", "passwordRESET", "CITIZEN", null);
+		final Otp otp = new Otp("mobileNumber", "tenantId", "passwordRESET", "CITIZEN", null, null);
 		final OtpRequest request = new OtpRequest(null, otp);
 
 		final org.egov.domain.model.OtpRequest domainOtpRequest = request.toDomain();
@@ -64,7 +64,7 @@ public class OtpRequestTest {
 	
 	@Test
 	public void test_should_set_request_type_login_when_type_is_login() {
-		final Otp otp = new Otp("mobileNumber", "tenantId", "LOGIN", "CITIZEN", null);
+		final Otp otp = new Otp("mobileNumber", "tenantId", "LOGIN", "CITIZEN", null, null);
 		final OtpRequest request = new OtpRequest(null, otp);
 
 		final org.egov.domain.model.OtpRequest domainOtpRequest = request.toDomain();
@@ -74,7 +74,7 @@ public class OtpRequestTest {
 	
 	@Test
 	public void test_should_set_request_type_to_login_when_type_is_login() {
-		final Otp otp = new Otp("mobileNumber", "tenantId", "login", "CITIZEN", null);
+		final Otp otp = new Otp("mobileNumber", "tenantId", "login", "CITIZEN", null, null);
 		final OtpRequest request = new OtpRequest(null, otp);
 
 		final org.egov.domain.model.OtpRequest domainOtpRequest = request.toDomain();


### PR DESCRIPTION
…tract

Otp.java's userName field bumped the Lombok all-args constructor from 5 to 6 params; update all constructor calls in OtpRequestTest to match.