### PR TITLE
Fix stale Otp/OtpRequest test constructors after userName field addit…

### DIFF
--- a/core-services/user-otp/src/test/java/org/egov/web/controller/OtpControllerTest.java
+++ b/core-services/user-otp/src/test/java/org/egov/web/controller/OtpControllerTest.java
@@ -45,13 +45,13 @@ public class OtpControllerTest {
 				.content(resources.getFileContents("otpSendRequest.json"))).andExpect(status().isCreated())
 				.andExpect(content().json(resources.getFileContents("otpSendSuccessResponse.json")));
 
-		final OtpRequest expectedOtpRequest = new OtpRequest(null, "mobileNumber", "tenantId", OtpRequestType.PASSWORD_RESET, "CITIZEN", null, null, null);
+		final OtpRequest expectedOtpRequest = new OtpRequest(null, "mobileNumber", "tenantId", OtpRequestType.PASSWORD_RESET, "CITIZEN", null, null, null, null);
 		verify(otpService).sendOtp(expectedOtpRequest);
 	}
 
 	@Test
 	public void test_should_return_error_response_when_mandatory_fields_are_not_present_in_request() throws Exception {
-		final OtpRequest expectedOtpRequest = new OtpRequest(null, "", "", null, "CITIZEN", null, null, null);
+		final OtpRequest expectedOtpRequest = new OtpRequest(null, "", "", null, "CITIZEN", null, null, null, null);
 		doThrow(new InvalidOtpRequestException(expectedOtpRequest)).when(otpService).sendOtp(expectedOtpRequest);
 
 		mockMvc.perform(post("/v1/_send").contentType(MediaType.APPLICATION_JSON_UTF8)
@@ -63,7 +63,7 @@ public class OtpControllerTest {
 	@Test
 	public void test_should_return_error_response_when_user_not_found_for_sending_forgot_password_otp()
 			throws Exception {
-		final OtpRequest expectedOtpRequest = new OtpRequest(null, "", "", null, "CITIZEN", null, null, null);
+		final OtpRequest expectedOtpRequest = new OtpRequest(null, "", "", null, "CITIZEN", null, null, null, null);
 		doThrow(new UserNotFoundException()).when(otpService).sendOtp(expectedOtpRequest);
 
 		mockMvc.perform(post("/v1/_send").contentType(MediaType.APPLICATION_JSON_UTF8)
@@ -74,7 +74,7 @@ public class OtpControllerTest {
 
 	@Test
 	public void test_should_return_error_response_when_user_alreadyExist_incaseoftypeisregister() throws Exception {
-		final OtpRequest expectedOtpRequest = new OtpRequest(null, "mobileNumber", "tenantId", OtpRequestType.REGISTER, "CITIZEN", null, null, null);
+		final OtpRequest expectedOtpRequest = new OtpRequest(null, "mobileNumber", "tenantId", OtpRequestType.REGISTER, "CITIZEN", null, null, null, null);
 		doThrow(new UserAlreadyExistInSystemException()).when(otpService).sendOtp(expectedOtpRequest);
 
 		mockMvc.perform(post("/v1/_send").contentType(MediaType.APPLICATION_JSON_UTF8)
@@ -84,7 +84,7 @@ public class OtpControllerTest {
 
 	@Test
 	public void test_should_return_error_response_when_user_doesntExist_incaseoftypeislogin() throws Exception {
-		final OtpRequest expectedOtpRequest = new OtpRequest(null, "mobileNumber", "tenantId", OtpRequestType.LOGIN, "CITIZEN", null, null, null);
+		final OtpRequest expectedOtpRequest = new OtpRequest(null, "mobileNumber", "tenantId", OtpRequestType.LOGIN, "CITIZEN", null, null, null, null);
 		doThrow(new UserNotExistingInSystemException()).when(otpService).sendOtp(expectedOtpRequest);
 
 		mockMvc.perform(post("/v1/_send").contentType(MediaType.APPLICATION_JSON_UTF8)
@@ -95,7 +95,7 @@ public class OtpControllerTest {
 	@Test
 	public void test_should_return_error_response_when_user_mobilenot_found_for_sending_forgot_password_otp()
 			throws Exception {
-		final OtpRequest expectedOtpRequest = new OtpRequest(null, "", "", null, "CITIZEN", null, null, null);
+		final OtpRequest expectedOtpRequest = new OtpRequest(null, "", "", null, "CITIZEN", null, null, null, null);
 		doThrow(new UserMobileNumberNotFoundException()).when(otpService).sendOtp(expectedOtpRequest);
 
 		mockMvc.perform(post("/v1/_send").contentType(MediaType.APPLICATION_JSON_UTF8)
@@ -106,7 +106,7 @@ public class OtpControllerTest {
 
 	@Test
 	public void test_should_return_error_message_when_unhandled_exception_occurs() throws Exception {
-		final OtpRequest expectedOtpRequest = new OtpRequest(null, "mobileNumber", "tenantId", null, "CITIZEN", null, null, null);
+		final OtpRequest expectedOtpRequest = new OtpRequest(null, "mobileNumber", "tenantId", null, "CITIZEN", null, null, null, null);
 		final String exceptionMessage = "Some exception message";
 		doThrow(new RuntimeException(exceptionMessage)).when(otpService).sendOtp(expectedOtpRequest);
 


### PR DESCRIPTION
…ions

web.contract.Otp and domain.model.OtpRequest each grew new fields (userName, mdmsValidationConfig, mdmsValidationErrorMessage) as part of this branch's userName-support work, but OtpRequestTest and OtpControllerTest still called the old, shorter constructors. Update all call sites to match the current arity.