### PR TITLE
fix(user-otp): backfill mobileNumber from resolved user for userName-…

### DIFF
--- a/core-services/user-otp/src/main/java/org/egov/domain/service/OtpService.java
+++ b/core-services/user-otp/src/main/java/org/egov/domain/service/OtpService.java
@@ -57,6 +57,9 @@ public class OtpService {
         else if (otpRequest.isLoginRequestType() && null == matchingUser)
             throw new UserNotExistingInSystemException();
 
+        if (otpRequest.isMobileNumberAbsent() && null != matchingUser)
+            otpRequest.setMobileNumber(matchingUser.getMobileNumber());
+
         final String otpNumber = otpRepository.fetchOtp(otpRequest);
         otpSMSSender.send(otpRequest, otpNumber);
         if(!otpRequest.isRegistrationRequestType()) // Because new user doesn't have any email configured


### PR DESCRIPTION
…only OTP requests

Login/registration OTP requests sent with only userName (e.g. employee forgot-password) reached otpRepository.fetchOtp() with mobileNumber still null. egov-otp then rejected the request for missing identity, and that rejection surfaced at user-otp as an unhandled empty-body 500 instead of a clean error. Backfill mobileNumber from the already-resolved matchingUser before fetching the OTP, mirroring what sendOtpForPasswordReset already does.