### PR TITLE
fix(user-otp): set mobileNumber before fetching OTP in password-reset…

### DIFF
--- a/core-services/user-otp/src/main/java/org/egov/domain/service/OtpService.java
+++ b/core-services/user-otp/src/main/java/org/egov/domain/service/OtpService.java
@@ -79,9 +79,9 @@ public class OtpService {
         }
         if (null == matchingUser.getMobileNumber() || matchingUser.getMobileNumber().isEmpty())
             throw new UserMobileNumberNotFoundException();
+        otpRequest.setMobileNumber(matchingUser.getMobileNumber());
         try {
             final String otpNumber = otpRepository.fetchOtp(otpRequest);
-            otpRequest.setMobileNumber(matchingUser.getMobileNumber());
             otpSMSSender.send(otpRequest, otpNumber);
             try {
                 otpEmailRepository.send(matchingUser.getEmail(), otpNumber, otpRequest);


### PR DESCRIPTION
… flow

sendOtpForPasswordReset() called otpRepository.fetchOtp() before setting otpRequest.mobileNumber from the resolved matchingUser, so egov-otp always received a null identity for userName-only requests (e.g. employee forgot-password) and rejected it with a 400. That failure was then swallowed by this method's blanket catch(Exception), so the caller still got back a fake 201 success with no OTP actually sent. Move the mobileNumber assignment above fetchOtp() so it's set before egov-otp is called.