### PR TITLE
CR: Enforce Single Active Login Session Per User

### DIFF
--- a/core-services/egov-user/src/main/java/org/egov/user/EgovUserApplication.java
+++ b/core-services/egov-user/src/main/java/org/egov/user/EgovUserApplication.java
@@ -107,6 +107,18 @@ public class EgovUserApplication {
         });
     }
 
+    // Dedicated pool for the single-active-login lastServerContact refresh, so that write
+    // never blocks the authenticated-request hot path it's invoked from.
+    @Bean(name = "sessionContactPool")
+    public ExecutorService sessionContactPool(
+            @Value("${egov.user.session.contact.pool.threads:2}") int threads) {
+        return Executors.newFixedThreadPool(threads, r -> {
+            Thread t = new Thread(r, "session-contact-worker");
+            t.setDaemon(true);
+            return t;
+        });
+    }
+
     @Bean
     public TokenStore tokenStore() {
         RedisTokenStore redisTokenStore = new RedisTokenStore(connectionFactory());

--- a/core-services/egov-user/src/main/java/org/egov/user/config/UserServiceConstants.java
+++ b/core-services/egov-user/src/main/java/org/egov/user/config/UserServiceConstants.java
@@ -88,5 +88,13 @@ public class UserServiceConstants {
     public static final String ERR_INVALID_SWITCH_REQUEST = "INVALID_SWITCH_REQUEST";
     public static final String ERR_LOGIN_FAILED = "LOGIN_FAILED";
 
+    // Single active login session constants
+    public static final String DEVICE_ID_DETAIL_KEY = "deviceId";
+    public static final String ACTIVE_SESSION_EXISTS_MESSAGE = "ACTIVE_SESSION_EXISTS: This user is already logged in on another device.";
+    public static final String ERR_SESSION_INVALID = "SESSION_INVALID";
+    public static final String SESSION_INVALID_MESSAGE = "Session is no longer valid";
+    public static final String ERR_NO_ACTIVE_SESSION = "NO_ACTIVE_SESSION";
+    public static final String NO_ACTIVE_SESSION_MESSAGE = "No active session found for this user";
+
 }
 

--- a/core-services/egov-user/src/main/java/org/egov/user/domain/model/enums/SessionStatus.java
+++ b/core-services/egov-user/src/main/java/org/egov/user/domain/model/enums/SessionStatus.java
@@ -1,0 +1,5 @@
+package org.egov.user.domain.model.enums;
+
+public enum SessionStatus {
+    ACTIVE, LOGGED_OUT, REVOKED
+}

--- a/core-services/egov-user/src/main/java/org/egov/user/domain/service/TokenService.java
+++ b/core-services/egov-user/src/main/java/org/egov/user/domain/service/TokenService.java
@@ -19,12 +19,16 @@ public class TokenService {
 
     private ActionRestRepository actionRestRepository;
 
+    private UserSessionService userSessionService;
+
     @Value("${roles.state.level.enabled}")
     private boolean isRoleStateLevel;
 
-    private TokenService(TokenStore tokenStore, ActionRestRepository actionRestRepository) {
+    private TokenService(TokenStore tokenStore, ActionRestRepository actionRestRepository,
+                          UserSessionService userSessionService) {
         this.tokenStore = tokenStore;
         this.actionRestRepository = actionRestRepository;
+        this.userSessionService = userSessionService;
     }
 
     /**
@@ -45,6 +49,7 @@ public class TokenService {
         }
 
         SecureUser secureUser = ((SecureUser) authentication.getPrincipal());
+        userSessionService.validateAndTouch(secureUser.getUser().getSessionId(), secureUser.getTenantId());
         return new UserDetail(secureUser, null);
 //		String tenantId = null;
 //		if (isRoleStateLevel && (secureUser.getTenantId() != null && secureUser.getTenantId().contains(".")))

--- a/core-services/egov-user/src/main/java/org/egov/user/domain/service/UserSessionService.java
+++ b/core-services/egov-user/src/main/java/org/egov/user/domain/service/UserSessionService.java
@@ -1,0 +1,138 @@
+package org.egov.user.domain.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.egov.tracer.model.CustomException;
+import org.egov.user.domain.model.enums.SessionStatus;
+import org.egov.user.persistence.dto.UserSession;
+import org.egov.user.persistence.repository.UserSessionRepository;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.security.oauth2.common.exceptions.OAuth2Exception;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+
+import static org.egov.user.config.UserServiceConstants.ACTIVE_SESSION_EXISTS_MESSAGE;
+import static org.egov.user.config.UserServiceConstants.ERR_NO_ACTIVE_SESSION;
+import static org.egov.user.config.UserServiceConstants.ERR_SESSION_INVALID;
+import static org.egov.user.config.UserServiceConstants.NO_ACTIVE_SESSION_MESSAGE;
+import static org.egov.user.config.UserServiceConstants.SESSION_INVALID_MESSAGE;
+
+/**
+ * Backend source of truth for single-active-login enforcement. Deliberately does not
+ * introduce any scheduler/expiry mechanism — sessions only change state in response to a
+ * login, logout, admin revoke, or an authenticated request from the owning device.
+ */
+@Service
+@Slf4j
+public class UserSessionService {
+
+    private final UserSessionRepository userSessionRepository;
+    private final ExecutorService sessionContactPool;
+
+    @Value("${egov.user.session.last.contact.interval.seconds:60}")
+    private long lastContactIntervalSeconds;
+
+    public UserSessionService(UserSessionRepository userSessionRepository,
+                               @Qualifier("sessionContactPool") ExecutorService sessionContactPool) {
+        this.userSessionRepository = userSessionRepository;
+        this.sessionContactPool = sessionContactPool;
+    }
+
+    /**
+     * Creates a new ACTIVE session for user+tenant and returns its sessionId. Concurrency
+     * safety comes from the DB's partial unique index on (useruuid, tenantid) WHERE
+     * status='ACTIVE'; a losing concurrent login fails the INSERT here rather than racing a
+     * SELECT-then-INSERT.
+     *
+     * @throws OAuth2Exception if the user already has an ACTIVE session on another device.
+     *         Thrown as OAuth2Exception (not CustomException) because this runs inside
+     *         CustomAuthenticationProvider/CustomPreAuthenticatedProvider, which are invoked
+     *         from Spring's OAuth2 TokenEndpoint, not a normal @RestController.
+     */
+    public String createSession(String userUuid, String tenantId, String deviceId) {
+        String sessionId = UUID.randomUUID().toString();
+        long now = System.currentTimeMillis();
+        UserSession session = new UserSession(userUuid, tenantId, deviceId, sessionId,
+                SessionStatus.ACTIVE.name(), now, now);
+        try {
+            userSessionRepository.insertActiveSession(session);
+        } catch (DuplicateKeyException e) {
+            log.info("Duplicate login rejected for user {} tenant {}", userUuid, tenantId);
+            throw new OAuth2Exception(ACTIVE_SESSION_EXISTS_MESSAGE);
+        }
+        log.info("Session created for user {} tenant {} sessionId {}", userUuid, tenantId, sessionId);
+        return sessionId;
+    }
+
+    /**
+     * Validates the session backing an authenticated request and, only when its
+     * lastServerContact has gone stale, refreshes it asynchronously so the request is never
+     * delayed by the write. The same read used for status validation already carries
+     * lastServerContact, so the staleness decision needs no separate read.
+     *
+     * @param sessionId sessionId embedded in the token; null for tokens issued before this
+     *                   feature, which are allowed through unchanged for backward compatibility.
+     * @throws CustomException if a session record exists for this id but is no longer ACTIVE
+     *         (logged out or revoked), or if no record exists at all for a non-null id.
+     */
+    public void validateAndTouch(String sessionId, String tenantId) {
+        if (sessionId == null) {
+            return;
+        }
+
+        Optional<UserSession> sessionOpt = userSessionRepository.findBySessionId(sessionId, tenantId);
+        if (!sessionOpt.isPresent()) {
+            log.warn("No session record found for sessionId {}", sessionId);
+            throw new CustomException(ERR_SESSION_INVALID, SESSION_INVALID_MESSAGE);
+        }
+
+        UserSession session = sessionOpt.get();
+        if (!SessionStatus.ACTIVE.name().equals(session.getStatus())) {
+            log.info("Rejected request for {} session {}", session.getStatus(), sessionId);
+            throw new CustomException(ERR_SESSION_INVALID, SESSION_INVALID_MESSAGE);
+        }
+
+        long now = System.currentTimeMillis();
+        long staleBefore = now - (lastContactIntervalSeconds * 1000);
+        if (session.getLastServerContact() < staleBefore) {
+            sessionContactPool.submit(() -> {
+                try {
+                    userSessionRepository.touchLastServerContact(sessionId, tenantId, now, staleBefore);
+                } catch (Exception e) {
+                    log.warn("Failed to update lastServerContact for session {}", sessionId, e);
+                }
+            });
+        }
+    }
+
+    /**
+     * Marks the session LOGGED_OUT. History is preserved (status update, not delete) so a
+     * subsequent login on another device is allowed.
+     */
+    public void logout(String sessionId, String tenantId) {
+        if (sessionId == null) {
+            return;
+        }
+        userSessionRepository.updateStatus(sessionId, tenantId, SessionStatus.LOGGED_OUT.name());
+        log.info("Session {} logged out", sessionId);
+    }
+
+    /**
+     * Administrative revoke for exceptional cases (e.g. lost/unavailable device). Only marks
+     * the DB session REVOKED — it does not and cannot force an already-offline device to react
+     * immediately; the device is blocked the next time it contacts the backend.
+     */
+    public void revoke(String userUuid, String tenantId) {
+        Optional<UserSession> activeSession = userSessionRepository.findActiveSession(userUuid, tenantId);
+        if (!activeSession.isPresent()) {
+            throw new CustomException(ERR_NO_ACTIVE_SESSION, NO_ACTIVE_SESSION_MESSAGE);
+        }
+        String sessionId = activeSession.get().getSessionId();
+        userSessionRepository.updateStatus(sessionId, tenantId, SessionStatus.REVOKED.name());
+        log.info("Session {} revoked for user {} tenant {}", sessionId, userUuid, tenantId);
+    }
+}

--- a/core-services/egov-user/src/main/java/org/egov/user/persistence/dto/UserSession.java
+++ b/core-services/egov-user/src/main/java/org/egov/user/persistence/dto/UserSession.java
@@ -1,0 +1,22 @@
+package org.egov.user.persistence.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Data
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserSession {
+
+    private String userUuid;
+    private String tenantId;
+    private String deviceId;
+    private String sessionId;
+    private String status;
+    private long createdTime;
+    private long lastServerContact;
+
+}

--- a/core-services/egov-user/src/main/java/org/egov/user/persistence/repository/UserSessionRepository.java
+++ b/core-services/egov-user/src/main/java/org/egov/user/persistence/repository/UserSessionRepository.java
@@ -1,0 +1,93 @@
+package org.egov.user.persistence.repository;
+
+import lombok.extern.slf4j.Slf4j;
+import org.egov.user.persistence.dto.UserSession;
+import org.egov.user.repository.builder.UserSessionQueryBuilder;
+import org.egov.user.utils.DatabaseSchemaUtils;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Repository
+@Slf4j
+public class UserSessionRepository {
+
+    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+    private final DatabaseSchemaUtils databaseSchemaUtils;
+
+    public UserSessionRepository(NamedParameterJdbcTemplate namedParameterJdbcTemplate,
+                                  DatabaseSchemaUtils databaseSchemaUtils) {
+        this.namedParameterJdbcTemplate = namedParameterJdbcTemplate;
+        this.databaseSchemaUtils = databaseSchemaUtils;
+    }
+
+    /**
+     * Inserts a new ACTIVE session row. Callers must catch
+     * {@link org.springframework.dao.DuplicateKeyException}: the partial unique index on
+     * (useruuid, tenantid) WHERE status='ACTIVE' is what makes this concurrency-safe, so a
+     * losing concurrent login surfaces here as a constraint violation, not as a missed check.
+     */
+    public void insertActiveSession(UserSession session) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("useruuid", session.getUserUuid());
+        params.put("tenantid", session.getTenantId());
+        params.put("deviceid", session.getDeviceId());
+        params.put("sessionid", session.getSessionId());
+        params.put("status", session.getStatus());
+        params.put("createdtime", session.getCreatedTime());
+        params.put("lastservercontact", session.getLastServerContact());
+
+        String query = databaseSchemaUtils.replaceSchemaPlaceholder(
+                UserSessionQueryBuilder.INSERT_ACTIVE_SESSION_SQL, session.getTenantId());
+        namedParameterJdbcTemplate.update(query, params);
+    }
+
+    public Optional<UserSession> findBySessionId(String sessionId, String tenantId) {
+        String query = databaseSchemaUtils.replaceSchemaPlaceholder(
+                UserSessionQueryBuilder.SELECT_SESSION_BY_SESSIONID_SQL, tenantId);
+        List<UserSession> results = namedParameterJdbcTemplate.query(query,
+                Collections.singletonMap("sessionid", sessionId), new BeanPropertyRowMapper<>(UserSession.class));
+        return results.stream().findFirst();
+    }
+
+    public Optional<UserSession> findActiveSession(String userUuid, String tenantId) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("useruuid", userUuid);
+        params.put("tenantid", tenantId);
+        String query = databaseSchemaUtils.replaceSchemaPlaceholder(
+                UserSessionQueryBuilder.SELECT_ACTIVE_SESSION_BY_USER_TENANT_SQL, tenantId);
+        List<UserSession> results = namedParameterJdbcTemplate.query(query, params,
+                new BeanPropertyRowMapper<>(UserSession.class));
+        return results.stream().findFirst();
+    }
+
+    public void updateStatus(String sessionId, String tenantId, String newStatus) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("sessionid", sessionId);
+        params.put("status", newStatus);
+        String query = databaseSchemaUtils.replaceSchemaPlaceholder(
+                UserSessionQueryBuilder.UPDATE_SESSION_STATUS_SQL, tenantId);
+        namedParameterJdbcTemplate.update(query, params);
+    }
+
+    /**
+     * Fire-and-forget-safe: a single atomic conditional UPDATE, no read involved. If another
+     * request already refreshed the timestamp inside the debounce window, this simply matches
+     * zero rows.
+     */
+    public void touchLastServerContact(String sessionId, String tenantId, long now, long staleBefore) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("sessionid", sessionId);
+        params.put("now", now);
+        params.put("staleBefore", staleBefore);
+        String query = databaseSchemaUtils.replaceSchemaPlaceholder(
+                UserSessionQueryBuilder.TOUCH_LAST_SERVER_CONTACT_SQL, tenantId);
+        namedParameterJdbcTemplate.update(query, params);
+    }
+}

--- a/core-services/egov-user/src/main/java/org/egov/user/repository/builder/UserSessionQueryBuilder.java
+++ b/core-services/egov-user/src/main/java/org/egov/user/repository/builder/UserSessionQueryBuilder.java
@@ -1,0 +1,43 @@
+package org.egov.user.repository.builder;
+
+import static org.egov.user.utils.DatabaseSchemaUtils.SCHEMA_REPLACE_STRING;
+
+/**
+ * SQL for the single-active-login session table (eg_user_session). Every statement is
+ * schema-templated via {@link org.egov.user.utils.DatabaseSchemaUtils#SCHEMA_REPLACE_STRING},
+ * matching the pattern used by UserRepository/RoleRepository/BulkUserRepository for
+ * central-instance compatibility.
+ */
+public final class UserSessionQueryBuilder {
+
+    private UserSessionQueryBuilder() {
+    }
+
+    public static final String INSERT_ACTIVE_SESSION_SQL =
+            "INSERT INTO " + SCHEMA_REPLACE_STRING + ".eg_user_session " +
+            "(useruuid, tenantid, deviceid, sessionid, status, createdtime, lastservercontact) " +
+            "VALUES (:useruuid, :tenantid, :deviceid, :sessionid, :status, :createdtime, :lastservercontact)";
+
+    public static final String SELECT_SESSION_BY_SESSIONID_SQL =
+            "SELECT useruuid, tenantid, deviceid, sessionid, status, createdtime, lastservercontact " +
+            "FROM " + SCHEMA_REPLACE_STRING + ".eg_user_session WHERE sessionid = :sessionid";
+
+    public static final String SELECT_ACTIVE_SESSION_BY_USER_TENANT_SQL =
+            "SELECT useruuid, tenantid, deviceid, sessionid, status, createdtime, lastservercontact " +
+            "FROM " + SCHEMA_REPLACE_STRING + ".eg_user_session " +
+            "WHERE useruuid = :useruuid AND tenantid = :tenantid AND status = 'ACTIVE'";
+
+    // Only transitions a row that is currently ACTIVE — a stale/already-terminated session
+    // is left untouched instead of being re-stamped with a new terminal status.
+    public static final String UPDATE_SESSION_STATUS_SQL =
+            "UPDATE " + SCHEMA_REPLACE_STRING + ".eg_user_session SET status = :status " +
+            "WHERE sessionid = :sessionid AND status = 'ACTIVE'";
+
+    // Single atomic, conditional write: only applies (and only costs a write) when the stored
+    // lastservercontact is older than the debounce window, so no separate read is needed to
+    // decide whether to update it.
+    public static final String TOUCH_LAST_SERVER_CONTACT_SQL =
+            "UPDATE " + SCHEMA_REPLACE_STRING + ".eg_user_session SET lastservercontact = :now " +
+            "WHERE sessionid = :sessionid AND status = 'ACTIVE' AND lastservercontact < :staleBefore";
+
+}

--- a/core-services/egov-user/src/main/java/org/egov/user/security/oauth2/custom/authproviders/CustomAuthenticationProvider.java
+++ b/core-services/egov-user/src/main/java/org/egov/user/security/oauth2/custom/authproviders/CustomAuthenticationProvider.java
@@ -23,6 +23,7 @@ import org.egov.user.domain.model.SecureUser;
 import org.egov.user.domain.model.User;
 import org.egov.user.domain.model.enums.UserType;
 import org.egov.user.domain.service.UserService;
+import org.egov.user.domain.service.UserSessionService;
 import org.egov.user.domain.service.utils.EncryptionDecryptionUtil;
 import org.egov.user.utils.DatabaseSchemaUtils;
 import org.egov.user.web.contract.auth.Role;
@@ -57,6 +58,9 @@ public class CustomAuthenticationProvider implements AuthenticationProvider {
     
     @Autowired
     private EncryptionDecryptionUtil encryptionDecryptionUtil;
+
+    @Autowired
+    private UserSessionService userSessionService;
 
     @Value("${citizen.login.password.otp.enabled}")
     private boolean citizenLoginPasswordOtpEnabled;
@@ -166,7 +170,10 @@ public class CustomAuthenticationProvider implements AuthenticationProvider {
 			 */
             List<GrantedAuthority> grantedAuths = new ArrayList<>();
             grantedAuths.add(new SimpleGrantedAuthority("ROLE_" + user.getType()));
-            final SecureUser secureUser = new SecureUser(getUser(user));
+            org.egov.user.web.contract.auth.User authUser = getUser(user);
+            String deviceId = details.get(UserServiceConstants.DEVICE_ID_DETAIL_KEY);
+            authUser.setSessionId(userSessionService.createSession(user.getUuid(), tenantId, deviceId));
+            final SecureUser secureUser = new SecureUser(authUser);
             userService.resetFailedLoginAttempts(user);
             return new UsernamePasswordAuthenticationToken(secureUser,
                     password, grantedAuths);

--- a/core-services/egov-user/src/main/java/org/egov/user/security/oauth2/custom/authproviders/CustomPreAuthenticatedProvider.java
+++ b/core-services/egov-user/src/main/java/org/egov/user/security/oauth2/custom/authproviders/CustomPreAuthenticatedProvider.java
@@ -10,7 +10,9 @@ import org.egov.user.domain.model.SecureUser;
 import org.egov.user.domain.model.User;
 import org.egov.user.domain.model.enums.UserType;
 import org.egov.user.domain.service.UserService;
+import org.egov.user.domain.service.UserSessionService;
 import org.egov.user.domain.service.utils.EncryptionDecryptionUtil;
+import org.egov.user.config.UserServiceConstants;
 import org.egov.user.web.contract.auth.Role;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,6 +43,9 @@ public class CustomPreAuthenticatedProvider implements AuthenticationProvider {
 
     @Autowired
     private EncryptionDecryptionUtil encryptionDecryptionUtil;
+
+    @Autowired
+    private UserSessionService userSessionService;
 
     @Override
     public Authentication authenticate(Authentication authentication) throws AuthenticationException {
@@ -90,7 +95,10 @@ public class CustomPreAuthenticatedProvider implements AuthenticationProvider {
 
         List<GrantedAuthority> grantedAuths = new ArrayList<>();
         grantedAuths.add(new SimpleGrantedAuthority("ROLE_" + user.getType()));
-        final SecureUser finalUser = new SecureUser(getUser(user));
+        org.egov.user.web.contract.auth.User authUser = getUser(user);
+        String deviceId = details.get(UserServiceConstants.DEVICE_ID_DETAIL_KEY);
+        authUser.setSessionId(userSessionService.createSession(user.getUuid(), tenantId, deviceId));
+        final SecureUser finalUser = new SecureUser(authUser);
         return new PreAuthenticatedAuthenticationToken(finalUser,
                 null, grantedAuths);
     }

--- a/core-services/egov-user/src/main/java/org/egov/user/web/contract/RevokeSessionRequest.java
+++ b/core-services/egov-user/src/main/java/org/egov/user/web/contract/RevokeSessionRequest.java
@@ -1,0 +1,32 @@
+package org.egov.user.web.contract;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.egov.common.contract.request.RequestInfo;
+import org.egov.user.config.UserServiceConstants;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+
+@Getter
+@Setter
+@ToString
+public class RevokeSessionRequest {
+
+    @JsonProperty("RequestInfo")
+    private RequestInfo requestInfo;
+
+    @NotNull(message = "userUuid is mandatory")
+    @Size(max = 64)
+    @JsonProperty("userUuid")
+    private String userUuid;
+
+    @NotNull(message = "tenantId is mandatory")
+    @Pattern(regexp = UserServiceConstants.PATTERN_TENANT)
+    @Size(max = 256)
+    @JsonProperty("tenantId")
+    private String tenantId;
+}

--- a/core-services/egov-user/src/main/java/org/egov/user/web/contract/auth/User.java
+++ b/core-services/egov-user/src/main/java/org/egov/user/web/contract/auth/User.java
@@ -25,4 +25,8 @@ public class User implements Serializable {
     private boolean active;
     private String tenantId;
     private String permanentCity;
+    // Backend session handle for single-active-login enforcement. Null for tokens issued
+    // before this feature — TokenService treats that as "no session enforcement" rather
+    // than rejecting the request, so pre-existing tokens keep working across rollout.
+    private String sessionId;
 }

--- a/core-services/egov-user/src/main/java/org/egov/user/web/controller/LogoutController.java
+++ b/core-services/egov-user/src/main/java/org/egov/user/web/controller/LogoutController.java
@@ -3,7 +3,9 @@ package org.egov.user.web.controller;
 import org.egov.common.contract.response.Error;
 import org.egov.common.contract.response.ErrorResponse;
 import org.egov.common.contract.response.ResponseInfo;
+import org.egov.user.config.UserServiceConstants;
 import org.egov.user.domain.model.TokenWrapper;
+import org.egov.user.domain.service.UserSessionService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
@@ -17,9 +19,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class LogoutController {
 
     private TokenStore tokenStore;
+    private UserSessionService userSessionService;
 
-    public LogoutController(TokenStore tokenStore) {
+    public LogoutController(TokenStore tokenStore, UserSessionService userSessionService) {
         this.tokenStore = tokenStore;
+        this.userSessionService = userSessionService;
     }
 
     /**
@@ -30,16 +34,36 @@ public class LogoutController {
      * @throws Exception
      */
     @PostMapping("/_logout")
-    public ResponseInfo deleteToken(@RequestBody TokenWrapper tokenWrapper) throws Exception {
+    public ResponseEntity<?> deleteToken(@RequestBody TokenWrapper tokenWrapper) throws Exception {
         String accessToken = tokenWrapper.getAccessToken();
         OAuth2AccessToken redisToken = tokenStore.readAccessToken(accessToken);
+        if (redisToken == null) {
+            return buildLogoutFailedResponse();
+        }
+        markSessionLoggedOut(redisToken);
         tokenStore.removeAccessToken(redisToken);
-        return new ResponseInfo("", "", System.currentTimeMillis(), "", "", "Logout successfully");
+        ResponseInfo responseInfo = new ResponseInfo("", "", System.currentTimeMillis(), "", "", "Logout successfully");
+        return new ResponseEntity<>(responseInfo, HttpStatus.OK);
+    }
+
+    private void markSessionLoggedOut(OAuth2AccessToken redisToken) {
+        if (redisToken == null || redisToken.getAdditionalInformation() == null) {
+            return;
+        }
+        Object userRequestObj = redisToken.getAdditionalInformation().get(UserServiceConstants.USER_REQUEST_KEY);
+        if (userRequestObj instanceof org.egov.user.web.contract.auth.User) {
+            org.egov.user.web.contract.auth.User user = (org.egov.user.web.contract.auth.User) userRequestObj;
+            userSessionService.logout(user.getSessionId(), user.getTenantId());
+        }
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleError(Exception ex) {
         ex.printStackTrace();
+        return buildLogoutFailedResponse();
+    }
+
+    private ResponseEntity<ErrorResponse> buildLogoutFailedResponse() {
         ErrorResponse response = new ErrorResponse();
         ResponseInfo responseInfo = new ResponseInfo("", "", System.currentTimeMillis(), "", "", "Logout failed");
         response.setResponseInfo(responseInfo);

--- a/core-services/egov-user/src/main/java/org/egov/user/web/controller/UserSessionController.java
+++ b/core-services/egov-user/src/main/java/org/egov/user/web/controller/UserSessionController.java
@@ -1,0 +1,46 @@
+package org.egov.user.web.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.egov.common.contract.response.ResponseInfo;
+import org.egov.user.domain.service.UserSessionService;
+import org.egov.user.web.contract.RevokeSessionRequest;
+import org.egov.user.web.contract.factory.ResponseInfoFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Administrative session-revoke for exceptional cases (e.g. a lost/unavailable device).
+ * Authorization is enforced the same way as every other privileged endpoint in this
+ * service: via the gateway's role-action (RBAC) mapping, not in-service Spring Security —
+ * see SecurityConfig, which performs no in-service RBAC of its own.
+ */
+@RestController
+@Slf4j
+public class UserSessionController {
+
+    private final UserSessionService userSessionService;
+    private final ResponseInfoFactory responseInfoFactory;
+
+    public UserSessionController(UserSessionService userSessionService, ResponseInfoFactory responseInfoFactory) {
+        this.userSessionService = userSessionService;
+        this.responseInfoFactory = responseInfoFactory;
+    }
+
+    @PostMapping("/user-session/v1/_revoke")
+    public ResponseEntity<Map<String, Object>> revoke(@Valid @RequestBody RevokeSessionRequest request) {
+        log.info("Session revoke requested for user: {} tenant: {}", request.getUserUuid(), request.getTenantId());
+        userSessionService.revoke(request.getUserUuid(), request.getTenantId());
+
+        ResponseInfo responseInfo = responseInfoFactory.createResponseInfoFromRequestInfo(request.getRequestInfo(), true);
+        Map<String, Object> response = new HashMap<>();
+        response.put("ResponseInfo", responseInfo);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+}

--- a/core-services/egov-user/src/main/resources/application.properties
+++ b/core-services/egov-user/src/main/resources/application.properties
@@ -41,6 +41,9 @@ citizen.login.password.otp.fixed.enabled=false
 otp.validation.register.mandatory=true
 access.token.validity.in.minutes=10080
 refresh.token.validity.in.minutes=20160
+#----------------Single active login session config---------------------#
+egov.user.session.last.contact.interval.seconds=60
+egov.user.session.contact.pool.threads=2
 default.password.expiry.in.days=90
 mobile.number.validation.workaround.enabled=false
 roles.state.level.enabled=true

--- a/core-services/egov-user/src/main/resources/db/migration/ddl/V20260902120000__create_eg_user_session_table.sql
+++ b/core-services/egov-user/src/main/resources/db/migration/ddl/V20260902120000__create_eg_user_session_table.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS eg_user_session (
+    useruuid character varying(64) NOT NULL,
+    tenantid character varying(256) NOT NULL,
+    deviceid character varying(256),
+    sessionid character varying(64) NOT NULL,
+    status character varying(32) NOT NULL,
+    createdtime bigint NOT NULL,
+    lastservercontact bigint NOT NULL
+);
+
+-- Fast lookup for the hot authenticated-request path (validate by sessionId).
+CREATE UNIQUE INDEX IF NOT EXISTS uk_eg_user_session_sessionid ON eg_user_session (sessionid);
+
+-- Guarantees only one ACTIVE session per user+tenant even under concurrent logins:
+-- the second concurrent INSERT fails on this constraint instead of racing a SELECT.
+CREATE UNIQUE INDEX IF NOT EXISTS uk_eg_user_session_active_user_tenant
+    ON eg_user_session (useruuid, tenantid)
+    WHERE status = 'ACTIVE';

--- a/core-services/egov-user/src/test/java/org/egov/user/domain/service/TokenServiceTest.java
+++ b/core-services/egov-user/src/test/java/org/egov/user/domain/service/TokenServiceTest.java
@@ -21,8 +21,12 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.egov.tracer.model.CustomException;
+
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -36,6 +40,9 @@ public class TokenServiceTest {
 
     @Mock
     private ActionRestRepository actionRestRepository;
+
+    @Mock
+    private UserSessionService userSessionService;
 
     @Test
     public void test_should_get_user_details_for_given_token() {
@@ -62,6 +69,50 @@ public class TokenServiceTest {
         when(tokenStore.readAuthentication("accessToken")).thenReturn(null);
 
         tokenService.getUser("accessToken");
+    }
+
+    @Test
+    public void test_should_validate_session_using_sessionId_embedded_in_token() {
+        OAuth2Authentication oAuth2Authentication = mock(OAuth2Authentication.class);
+        final String accessToken = "c80e0ade-f48d-4077-b0d2-4e58526a6bfd";
+        when(tokenStore.readAuthentication(accessToken)).thenReturn(oAuth2Authentication);
+        User user = getUser();
+        user.setSessionId("session-123");
+        SecureUser secureUser = new SecureUser(user);
+        when(oAuth2Authentication.getPrincipal()).thenReturn(secureUser);
+
+        tokenService.getUser(accessToken);
+
+        verify(userSessionService).validateAndTouch("session-123", "default");
+    }
+
+    @Test
+    public void test_should_allow_token_with_no_sessionId_for_backward_compatibility() {
+        OAuth2Authentication oAuth2Authentication = mock(OAuth2Authentication.class);
+        final String accessToken = "c80e0ade-f48d-4077-b0d2-4e58526a6bfd";
+        when(tokenStore.readAuthentication(accessToken)).thenReturn(oAuth2Authentication);
+        SecureUser secureUser = new SecureUser(getUser());
+        when(oAuth2Authentication.getPrincipal()).thenReturn(secureUser);
+
+        UserDetail actualUserDetails = tokenService.getUser(accessToken);
+
+        assertEquals(secureUser, actualUserDetails.getSecureUser());
+        verify(userSessionService).validateAndTouch(null, "default");
+    }
+
+    @Test(expected = CustomException.class)
+    public void test_should_reject_request_when_session_is_no_longer_active() {
+        OAuth2Authentication oAuth2Authentication = mock(OAuth2Authentication.class);
+        final String accessToken = "c80e0ade-f48d-4077-b0d2-4e58526a6bfd";
+        when(tokenStore.readAuthentication(accessToken)).thenReturn(oAuth2Authentication);
+        User user = getUser();
+        user.setSessionId("session-123");
+        SecureUser secureUser = new SecureUser(user);
+        when(oAuth2Authentication.getPrincipal()).thenReturn(secureUser);
+        doThrow(new CustomException("SESSION_INVALID", "Session is no longer valid"))
+                .when(userSessionService).validateAndTouch("session-123", "default");
+
+        tokenService.getUser(accessToken);
     }
 
     private User getUser() {

--- a/core-services/egov-user/src/test/java/org/egov/user/domain/service/UserSessionServiceTest.java
+++ b/core-services/egov-user/src/test/java/org/egov/user/domain/service/UserSessionServiceTest.java
@@ -1,0 +1,227 @@
+package org.egov.user.domain.service;
+
+import org.egov.tracer.model.CustomException;
+import org.egov.user.persistence.dto.UserSession;
+import org.egov.user.persistence.repository.UserSessionRepository;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.security.oauth2.common.exceptions.OAuth2Exception;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UserSessionServiceTest {
+
+    @Mock
+    private UserSessionRepository userSessionRepository;
+
+    @Mock
+    private ExecutorService sessionContactPool;
+
+    private UserSessionService userSessionService;
+
+    private static final String USER_UUID = "user-uuid-1";
+    private static final String OTHER_USER_UUID = "user-uuid-2";
+    private static final String TENANT_ID = "pb.amritsar";
+    private static final String OTHER_TENANT_ID = "pb.jalandhar";
+
+    @Before
+    public void setUp() {
+        userSessionService = new UserSessionService(userSessionRepository, sessionContactPool);
+        ReflectionTestUtils.setField(userSessionService, "lastContactIntervalSeconds", 60L);
+    }
+
+    // Test 1 — first login: no active session, login succeeds, ACTIVE session created.
+    @Test
+    public void test_should_create_active_session_when_no_existing_active_session() {
+        String sessionId = userSessionService.createSession(USER_UUID, TENANT_ID, "device-A");
+
+        assertNotNull(sessionId);
+        ArgumentCaptor<UserSession> captor = ArgumentCaptor.forClass(UserSession.class);
+        verify(userSessionRepository).insertActiveSession(captor.capture());
+        UserSession inserted = captor.getValue();
+        assertEquals(USER_UUID, inserted.getUserUuid());
+        assertEquals(TENANT_ID, inserted.getTenantId());
+        assertEquals("device-A", inserted.getDeviceId());
+        assertEquals("ACTIVE", inserted.getStatus());
+        assertEquals(sessionId, inserted.getSessionId());
+    }
+
+    // Test 2 — second device login: Device A active, Device B login rejected, Device A remains ACTIVE.
+    @Test(expected = OAuth2Exception.class)
+    public void test_should_reject_login_when_active_session_already_exists() {
+        doThrow(new DuplicateKeyException("duplicate active session"))
+                .when(userSessionRepository).insertActiveSession(any(UserSession.class));
+
+        userSessionService.createSession(USER_UUID, TENANT_ID, "device-B");
+    }
+
+    // Test 7 — concurrent login: the DB's unique-index violation (surfaced as
+    // DuplicateKeyException) is the sole mechanism protecting against the race; no
+    // select-then-insert window exists in this code path.
+    @Test
+    public void test_should_translate_duplicate_key_violation_into_oauth2_exception_with_active_session_message() {
+        doThrow(new DuplicateKeyException("duplicate"))
+                .when(userSessionRepository).insertActiveSession(any(UserSession.class));
+
+        try {
+            userSessionService.createSession(USER_UUID, TENANT_ID, "device-B");
+        } catch (OAuth2Exception e) {
+            assertTrue(e.getMessage().startsWith("ACTIVE_SESSION_EXISTS"));
+            return;
+        }
+        throw new AssertionError("Expected OAuth2Exception was not thrown");
+    }
+
+    // Test 8 — different users: no interaction between two users' session creation.
+    @Test
+    public void test_should_allow_different_users_to_have_independent_active_sessions() {
+        userSessionService.createSession(USER_UUID, TENANT_ID, "device-A");
+        userSessionService.createSession(OTHER_USER_UUID, TENANT_ID, "device-B");
+
+        verify(userSessionRepository, times(2)).insertActiveSession(any(UserSession.class));
+    }
+
+    // Test 9 — different tenants: same user, different tenant, independent sessions.
+    @Test
+    public void test_should_allow_same_user_to_have_independent_active_sessions_per_tenant() {
+        userSessionService.createSession(USER_UUID, TENANT_ID, "device-A");
+        userSessionService.createSession(USER_UUID, OTHER_TENANT_ID, "device-A");
+
+        verify(userSessionRepository, times(2)).insertActiveSession(any(UserSession.class));
+    }
+
+    // Backward compatibility — tokens issued before this feature carry no sessionId.
+    @Test
+    public void test_should_allow_request_through_when_sessionId_is_null() {
+        userSessionService.validateAndTouch(null, TENANT_ID);
+
+        verify(userSessionRepository, never()).findBySessionId(anyString(), anyString());
+    }
+
+    // Test 5 — reconnect: ACTIVE session, request allowed, no exception.
+    @Test
+    public void test_should_allow_request_when_session_is_active_and_fresh() {
+        UserSession active = new UserSession(USER_UUID, TENANT_ID, "device-A", "session-1",
+                "ACTIVE", System.currentTimeMillis(), System.currentTimeMillis());
+        when(userSessionRepository.findBySessionId("session-1", TENANT_ID)).thenReturn(Optional.of(active));
+
+        userSessionService.validateAndTouch("session-1", TENANT_ID);
+
+        verify(sessionContactPool, never()).submit(any(Runnable.class));
+    }
+
+    // Test 6 — revoked session: reconnecting device is rejected.
+    @Test(expected = CustomException.class)
+    public void test_should_reject_request_when_session_is_revoked() {
+        UserSession revoked = new UserSession(USER_UUID, TENANT_ID, "device-A", "session-1",
+                "REVOKED", System.currentTimeMillis(), System.currentTimeMillis());
+        when(userSessionRepository.findBySessionId("session-1", TENANT_ID)).thenReturn(Optional.of(revoked));
+
+        userSessionService.validateAndTouch("session-1", TENANT_ID);
+    }
+
+    @Test(expected = CustomException.class)
+    public void test_should_reject_request_when_session_is_logged_out() {
+        UserSession loggedOut = new UserSession(USER_UUID, TENANT_ID, "device-A", "session-1",
+                "LOGGED_OUT", System.currentTimeMillis(), System.currentTimeMillis());
+        when(userSessionRepository.findBySessionId("session-1", TENANT_ID)).thenReturn(Optional.of(loggedOut));
+
+        userSessionService.validateAndTouch("session-1", TENANT_ID);
+    }
+
+    @Test(expected = CustomException.class)
+    public void test_should_reject_request_when_no_session_record_found_for_sessionId() {
+        when(userSessionRepository.findBySessionId("unknown-session", TENANT_ID)).thenReturn(Optional.empty());
+
+        userSessionService.validateAndTouch("unknown-session", TENANT_ID);
+    }
+
+    // lastServerContact refresh: dispatched asynchronously and only when stale — the request
+    // thread must never be the one performing the DB write.
+    @Test
+    public void test_should_dispatch_async_touch_when_last_contact_is_stale() {
+        long staleTime = System.currentTimeMillis() - 120_000; // 120s ago, older than 60s window
+        UserSession active = new UserSession(USER_UUID, TENANT_ID, "device-A", "session-1",
+                "ACTIVE", staleTime, staleTime);
+        when(userSessionRepository.findBySessionId("session-1", TENANT_ID)).thenReturn(Optional.of(active));
+
+        userSessionService.validateAndTouch("session-1", TENANT_ID);
+
+        ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+        verify(sessionContactPool).submit(captor.capture());
+        // The write itself must be atomic/conditional in the repository, not gated by a
+        // second read here — running the captured task should call touchLastServerContact once.
+        captor.getValue().run();
+        verify(userSessionRepository, times(1))
+                .touchLastServerContact(eq("session-1"), eq(TENANT_ID), anyLong(), anyLong());
+    }
+
+    @Test
+    public void test_should_not_dispatch_touch_when_last_contact_is_fresh() {
+        long freshTime = System.currentTimeMillis() - 5_000; // 5s ago, within 60s window
+        UserSession active = new UserSession(USER_UUID, TENANT_ID, "device-A", "session-1",
+                "ACTIVE", freshTime, freshTime);
+        when(userSessionRepository.findBySessionId("session-1", TENANT_ID)).thenReturn(Optional.of(active));
+
+        userSessionService.validateAndTouch("session-1", TENANT_ID);
+
+        verify(sessionContactPool, never()).submit(any(Runnable.class));
+        verify(userSessionRepository, never())
+                .touchLastServerContact(anyString(), anyString(), anyLong(), anyLong());
+    }
+
+    // Test 3 — logout: ACTIVE session marked LOGGED_OUT.
+    @Test
+    public void test_logout_should_mark_session_logged_out() {
+        userSessionService.logout("session-1", TENANT_ID);
+
+        verify(userSessionRepository).updateStatus("session-1", TENANT_ID, "LOGGED_OUT");
+    }
+
+    @Test
+    public void test_logout_should_be_noop_when_sessionId_is_null() {
+        userSessionService.logout(null, TENANT_ID);
+
+        verify(userSessionRepository, never()).updateStatus(anyString(), anyString(), anyString());
+    }
+
+    // Test 6 — admin revoke: ACTIVE session found and marked REVOKED.
+    @Test
+    public void test_revoke_should_mark_active_session_revoked() {
+        UserSession active = new UserSession(USER_UUID, TENANT_ID, "device-A", "session-1",
+                "ACTIVE", System.currentTimeMillis(), System.currentTimeMillis());
+        when(userSessionRepository.findActiveSession(USER_UUID, TENANT_ID)).thenReturn(Optional.of(active));
+
+        userSessionService.revoke(USER_UUID, TENANT_ID);
+
+        verify(userSessionRepository).updateStatus("session-1", TENANT_ID, "REVOKED");
+    }
+
+    @Test(expected = CustomException.class)
+    public void test_revoke_should_fail_when_no_active_session_exists() {
+        when(userSessionRepository.findActiveSession(USER_UUID, TENANT_ID)).thenReturn(Optional.empty());
+
+        userSessionService.revoke(USER_UUID, TENANT_ID);
+    }
+}


### PR DESCRIPTION
  - New eg_user_session table + UserSessionService: one ACTIVE session                                                                                                                                                              
    per user+tenant, enforced via a DB partial unique index so concurrent                                                                                                                                                           
    logins can't race past the check                                                                                                                                                                                                
  - sessionId is embedded in the OAuth2 token and validated on every                                                                                                                                                                
    authenticated request (TokenService), rejecting stale/revoked sessions                                                                                                                                                          
    immediately rather than waiting for token expiry                                                                                                                                                                                
  - Logout marks the session LOGGED_OUT; new admin endpoint                                                                                                                                                                         
    (/user-session/v1/_revoke) force-invalidates a lost/unavailable                                                                                                                                                                 
    device's session                                                                                                                                                                                                                
  - Fix LogoutController NPE when access_token is invalid or already                                                                                                                                                                
    removed from the token store  