### PR TITLE
feat: add JDK 21 build config and workflow alongside Java 17

### DIFF
--- a/.github/workflows/build-jdk21.yml
+++ b/.github/workflows/build-jdk21.yml
@@ -1,0 +1,252 @@
+name: Build Pipeline (JDK 21)
+
+on:
+  workflow_dispatch:
+    inputs:
+      service_folder:
+        description: 'Folder prefix for the service'
+        required: true
+        type: choice
+        options:
+          - core-services
+        default: core-services
+      service:
+        description: 'Name of the service to build and deploy'
+        required: true
+        type: choice
+        options:
+          - "mdms-v2"
+          - "audit-service"
+          - "boundary-service"
+          - "build"
+          - "chatbot"
+          - "docs"
+          - "egov-accesscontrol"
+          - "egov-common-masters"
+          - "egov-data-uploader"
+          - "egov-document-uploader"
+          - "egov-enc-service"
+          - "egov-filestore"
+          - "egov-idgen"
+          - "egov-indexer"
+          - "egov-localization"
+          - "egov-location"
+          - "egov-malware-detection"
+          - "egov-mdms-service"
+          - "egov-notification-mail"
+          - "egov-notification-sms"
+          - "egov-otp"
+          - "egov-persister"
+          - "egov-pg-service"
+          - "egov-searcher"
+          - "egov-telemetry"
+          - "egov-url-shortening"
+          - "egov-user-event"
+          - "egov-user"
+          - "egov-workflow-v2"
+          - "gateway"
+          - "internal-gateway-scg"
+          - "internal-gateway"
+          - "libraries"
+          - "national-dashboard-ingest"
+          - "national-dashboard-kafka-pipeline"
+          - "nlp-engine"
+          - "pdf-service"
+          - "report"
+          - "service-request"
+          - "tenant"
+          - "user-otp"
+          - "xstate-chatbot"
+          - "zuul"
+        default: "audit-service"
+
+# NOTE: build-config-jdk21.yml deliberately keeps the SAME image names as
+# build-config.yml, so this workflow pushes to the same egovio/<service>
+# repositories as .github/workflows/build.yaml. The tag carries a jdk21 marker
+# to keep the two apart:
+#
+#   build.yaml        egovio/<service>:<branch>-<hash>
+#   build-jdk21.yml   egovio/<service>:<branch>-jdk21-<hash>
+#
+# Both workflows can therefore run on the same commit without overwriting
+# each other.
+permissions:
+  contents: read
+
+jobs:
+  resolve-config:
+    runs-on: ubuntu-latest
+    outputs:
+      dockerfile_path: ${{ steps.pick_dockerfile.outputs.dockerfile_path }}
+      tag:              ${{ steps.tag.outputs.tag }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Install yq
+        run: |
+          VERSION="4.30.8"
+          URL="https://github.com/mikefarah/yq/releases/download/v${VERSION}/yq_linux_amd64"
+          sudo curl -sSL "$URL" -o /usr/local/bin/yq
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Determine Dockerfile path from build-config-jdk21.yml
+        id: pick_dockerfile
+        env:
+          SERVICE: ${{ github.event.inputs.service }}
+        run: |
+          # JDK 21 builders. build-config-jdk21.yml already maps each service to
+          # the right one, so egov-user / egov-user-chatbot resolve to
+          # build/maven-java8-jdk21/Dockerfile and everything else to
+          # build/maven-jdk21/Dockerfile.
+          DEFAULT_DOCKERFILE="build/maven-jdk21/Dockerfile"
+
+          echo "Looking for service '$SERVICE' in build-config-jdk21.yml..."
+          # head -n1: a few image-names appear in more than one job entry
+          DF=$(yq eval ".config[].build[] | select(.\"image-name\" == \"${SERVICE}\") | .dockerfile // \"\"" build/build-config-jdk21.yml | head -n1)
+
+          if [ -z "$DF" ] || [ "$DF" = "null" ]; then
+            echo "No entry found; defaulting to $DEFAULT_DOCKERFILE"
+            DF="$DEFAULT_DOCKERFILE"
+          else
+            echo "Found dockerfile: $DF"
+          fi
+
+          echo "dockerfile_path=$DF" >> "$GITHUB_OUTPUT"
+          echo "DOCKERFILE_PATH=$DF" >> "$GITHUB_ENV"
+
+      - name: Generate the Next Tag
+        id: tag
+        run: |
+          set -euxo pipefail
+          BRANCH="${GITHUB_REF##*/}"
+          HASH=$(git rev-parse --short HEAD)
+          # jdk21 marker keeps these images from colliding with the Java 17
+          # tags pushed by .github/workflows/build.yaml (<branch>-<hash>).
+          TAG="${BRANCH}-jdk21-${HASH}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "NEXT_TAG=$TAG" >> "$GITHUB_ENV"
+
+  build-matrix:
+    needs: resolve-config
+    # expose whether a DB folder was present
+    outputs:
+      db_folder_exists: ${{ steps.check-db-folder.outputs.folder_exists }}
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Check for DB folder
+        id: check-db-folder
+        env:
+          SERVICE: ${{ github.event.inputs.service }}
+          SERVICE_FOLDER: ${{ github.event.inputs.service_folder }}
+        run: |
+          BASE_PATH="${SERVICE_FOLDER}/${SERVICE}"
+      
+          if [ -d "$BASE_PATH/src/main/resources/db" ]; then
+            echo "folder_exists=true" >> "$GITHUB_OUTPUT"
+            echo "db_path=$BASE_PATH/src/main/resources/db" >> "$GITHUB_OUTPUT"
+      
+          elif [ -d "$BASE_PATH/migration" ]; then
+            echo "folder_exists=true" >> "$GITHUB_OUTPUT"
+            echo "db_path=$BASE_PATH/migration" >> "$GITHUB_OUTPUT"
+      
+          else
+            echo "folder_exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ vars.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+      - name: Build & push ${{ matrix.arch }} image
+        id: build_push_app
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ needs.resolve-config.outputs.dockerfile_path }}
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: egovio/${{ github.event.inputs.service }}:${{ needs.resolve-config.outputs.tag }}-${{ matrix.arch }}
+          build-args: |
+            WORK_DIR=${{ github.event.inputs.service_folder }}/${{ github.event.inputs.service }}
+
+      - name: Build and Push Database Docker Image
+        if: ${{ steps.check-db-folder.outputs.folder_exists == 'true' }}
+        id: build_push_db
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ steps.check-db-folder.outputs.db_path }}
+          file: ${{ steps.check-db-folder.outputs.db_path }}/Dockerfile
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: egovio/${{ github.event.inputs.service }}-db:${{ needs.resolve-config.outputs.tag }}-${{ matrix.arch }}
+
+  create-manifest:
+    needs: [build-matrix, resolve-config]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ vars.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+      - name: Create & push multi-arch manifest (application)
+        env:
+          SERVICE: ${{ github.event.inputs.service }}
+          TAG: ${{ needs.resolve-config.outputs.tag }}
+        run: |
+          docker buildx imagetools create \
+            --tag "egovio/${SERVICE}:${TAG}" \
+            "egovio/${SERVICE}:${TAG}-amd64" \
+            "egovio/${SERVICE}:${TAG}-arm64"
+
+      - name: Create & push multi-arch manifest (database)
+        if: ${{ needs.build-matrix.outputs.db_folder_exists == 'true' }}
+        env:
+          SERVICE: ${{ github.event.inputs.service }}
+          TAG: ${{ needs.resolve-config.outputs.tag }}
+        run: |
+          docker buildx imagetools create \
+            --tag "egovio/${SERVICE}-db:${TAG}" \
+            "egovio/${SERVICE}-db:${TAG}-amd64" \
+            "egovio/${SERVICE}-db:${TAG}-arm64"
+
+      - name: Add all image tags to GitHub summary
+        env:
+          DB_EXISTS: ${{ needs.build-matrix.outputs.db_folder_exists }}
+          SERVICE: ${{ github.event.inputs.service }}
+          TAG: ${{ needs.resolve-config.outputs.tag }}
+        run: |
+          echo "## App Docker images" >> $GITHUB_STEP_SUMMARY
+          echo "- \`egovio/${SERVICE}:${TAG}-amd64\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`egovio/${SERVICE}:${TAG}-arm64\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **multi‑arch** \`egovio/${SERVICE}:${TAG}\`" >> $GITHUB_STEP_SUMMARY
+
+          if [ "$DB_EXISTS" = "true" ]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "## DB Docker images" >> $GITHUB_STEP_SUMMARY
+            echo "- \`egovio/${SERVICE}-db:${TAG}-amd64\`" >> $GITHUB_STEP_SUMMARY
+            echo "- \`egovio/${SERVICE}-db:${TAG}-arm64\`" >> $GITHUB_STEP_SUMMARY
+            echo "- **multi‑arch** \`egovio/${SERVICE}-db:${TAG}\`" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/build/build-config-jdk21.yml
+++ b/build/build-config-jdk21.yml
@@ -1,0 +1,571 @@
+#
+# JDK 21 variant of build/build-config.yml
+#
+# Job names, work-dirs and image names match build/build-config.yml, so the two
+# configs are drop-in alternatives. Only the builder differs:
+#
+#   build/maven/Dockerfile        -> build/maven-jdk21/Dockerfile
+#     (Spring Boot 3.x / Java 17 bytecode, run on a JDK 21 JRE)
+#   build/maven-java8/Dockerfile  -> build/maven-java8-jdk21/Dockerfile
+#     (Spring Boot 1.5 / Java 8 bytecode, run on a JDK 21 JRE with JAXB
+#      injected and --add-opens applied)
+#
+# Both builders come from the maven-jdk21 branch. Neither recompiles for
+# Java 21 - they only move the runtime to JDK 21, which fixes cgroup v2 CPU
+# detection (JDK-8281181) and enables container-aware heap sizing + CDS.
+#
+# core-services/egov-user-chatbot builds the core-services/egov-user source
+# tree, so it uses the java8-jdk21 builder alongside the egov-user job.
+#
+# Not Java builds, left exactly as-is: db/migration dirs, nodejs (xstate-*),
+# frontend, and service-owned Dockerfiles (pdf-service, keycloak-spi,
+# nlp-engine, qr-scanner-ui, pgr-ai-chatbot).
+#
+# Two duplicate job entries present in build/build-config.yml are omitted here:
+#   - a second, stranded copy of core-services/egov-user-event (exact dup)
+#   - accelerators/sample-services/backend/java/egov-birth-service, which
+#     collides on the egov-birth-service image name and whose work-dir does
+#     not exist on any branch
+# So this file has 78 jobs where build/build-config.yml has 80.
+#
+# Because image names are shared with build/build-config.yml, only ONE of the
+# two configs should be wired into a given Jenkins folder at a time.
+#
+config:
+# Business Services
+  - name: "builds/Digit-Core/business-services/billing-service"
+    build:
+      - work-dir: "business-services/billing-service"
+        image-name: "billing-service"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+      - work-dir: "business-services/billing-service/src/main/resources/db"
+        image-name: "billing-service-db"
+
+  - name: "builds/Digit-Core/business-services/collection-services"
+    build:
+      - work-dir: "business-services/collection-services"
+        image-name: "collection-services"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+      - work-dir: "business-services/collection-services/src/main/resources/db"
+        image-name: "collection-services-db"
+
+  - name: "builds/Digit-Core/business-services/egf-instrument"
+    build:
+      - work-dir: "business-services/egf-instrument"
+        image-name: "egf-instrument"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+      - work-dir: "business-services/egf-instrument/src/main/resources/db"
+        image-name: "egf-instrument-db"
+
+  - name: "builds/Digit-Core/business-services/egf-master"
+    build:
+      - work-dir: "business-services/egf-master"
+        image-name: "egf-master"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+      - work-dir: "business-services/egf-master/src/main/resources/db"
+        image-name: "egf-master-db"
+
+  - name: "builds/Digit-Core/business-services/egov-apportion-service"
+    build:
+      - work-dir: "business-services/egov-apportion-service"
+        image-name: "egov-apportion-service"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+      - work-dir: "business-services/egov-apportion-service/src/main/resources/db"
+        image-name: "egov-apportion-service-db"
+        
+  - name: "builds/Digit-Core/business-services/egov-hrms"
+    build:
+      - work-dir: "business-services/egov-hrms"
+        image-name: "egov-hrms"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+      - work-dir: "business-services/egov-hrms/src/main/resources/db"
+        image-name: "egov-hrms-db"
+
+  - name: "builds/Digit-Core/business-services/finance-collections-voucher-consumer"
+    build:
+      - work-dir: "business-services/finance-collections-voucher-consumer"
+        image-name: "finance-collections-voucher-consumer"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+      - work-dir: "business-services/finance-collections-voucher-consumer/src/main/resources/db"
+        image-name: "finance-collections-voucher-consumer-db"
+
+  - name: "builds/Digit-Core/business-services/dashboard-analytics"
+    build:
+      - work-dir: "business-services/dashboard-analytics"
+        image-name: "dashboard-analytics"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+
+  - name: "builds/Digit-Core/business-services/dashboard-ingest"
+    build:
+      - work-dir: "business-services/dashboard-ingest"
+        image-name: "dashboard-ingest"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+  - name: "builds/Digit-Core/core-services/egov-accesscontrol"
+    build:
+      - work-dir: "core-services/egov-accesscontrol"
+        image-name: "egov-accesscontrol"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+# Core Services
+  - name: "builds/Digit-Core/core-services/audit-service"
+    build:
+      - work-dir: "core-services/audit-service"
+        image-name: "audit-service"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+      - work-dir: "core-services/audit-service/src/main/resources/db"
+        image-name: "audit-service-db"
+  - name: "builds/Digit-Core/core-services/egov-common-masters"
+    build:
+      - work-dir: "core-services/egov-common-masters"
+        image-name: "egov-common-masters"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+      - work-dir: "core-services/egov-common-masters/src/main/resources/db"
+        image-name: "egov-common-masters-db"
+
+  - name: "builds/Digit-Core/core-services/egov-data-uploader"
+    build:
+      - work-dir: "core-services/egov-data-uploader"
+        image-name: "egov-data-uploader"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+      - work-dir: "core-services/egov-data-uploader/src/main/resources/db"
+        image-name: "egov-data-uploader-db"
+
+  - name: "builds/Digit-Core/core-services/egov-enc-service"
+    build:
+      - work-dir: "core-services/egov-enc-service"
+        image-name: "egov-enc-service"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+      - work-dir: "core-services/egov-enc-service/src/main/resources/db"
+        image-name: "egov-enc-service-db"
+
+  - name: "builds/Digit-Core/core-services/egov-filestore"
+    build:
+      - work-dir: "core-services/egov-filestore"
+        image-name: "egov-filestore"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+      - work-dir: "core-services/egov-filestore/src/main/resources/db"
+        image-name: "egov-filestore-db"
+
+  - name: "builds/Digit-Core/core-services/egov-idgen"
+    build:
+      - work-dir: "core-services/egov-idgen"
+        image-name: "egov-idgen"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+      - work-dir: "core-services/egov-idgen/src/main/resources/db"
+        image-name: "egov-idgen-db"
+
+  - name: "builds/Digit-Core/core-services/egov-indexer"
+    build:
+      - work-dir: "core-services/egov-indexer"
+        image-name: "egov-indexer"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+      - work-dir: "core-services/egov-indexer/src/main/resources/db"
+        image-name: "egov-indexer-db"
+
+  - name: "builds/Digit-Core/core-services/egov-localization"
+    build:
+      - work-dir: "core-services/egov-localization"
+        image-name: "egov-localization"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+      - work-dir: "core-services/egov-localization/src/main/resources/db"
+        image-name: "egov-localization-db"
+
+  - name: "builds/Digit-Core/core-services/egov-location"
+    build:
+      - work-dir: "core-services/egov-location"
+        image-name: "egov-location"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+      - work-dir: "core-services/egov-location/src/main/resources/db"
+        image-name: "egov-location-db"
+
+  - name: "builds/Digit-Core/core-services/boundary-service"
+    build:
+      - work-dir: "core-services/boundary-service"
+        image-name: "boundary-service"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+      - work-dir: "core-services/boundary-service/src/main/resources/db"
+        image-name: "boundary-service-db"
+
+  - name: "builds/Digit-Core/core-services/egov-mdms-service"
+    build:
+      - work-dir: "core-services/egov-mdms-service"
+        image-name: "egov-mdms-service"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+
+  - name: "builds/Digit-Core/core-services/mdms-v2"
+    build:
+      - work-dir: "core-services/mdms-v2"
+        image-name: "mdms-v2"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+      - work-dir: "core-services/mdms-v2/src/main/resources/db"
+        image-name: "mdms-v2-db"
+
+  - name: "builds/Digit-Core/core-services/egov-notification-mail"
+    build:
+      - work-dir: "core-services/egov-notification-mail"
+        image-name: "egov-notification-mail"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+
+  - name: "builds/Digit-Core/core-services/egov-notification-sms"
+    build:
+      - work-dir: "core-services/egov-notification-sms"
+        image-name: "egov-notification-sms"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+
+  - name: "builds/Digit-Core/core-services/egov-otp"
+    build:
+      - work-dir: "core-services/egov-otp"
+        image-name: "egov-otp"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+      - work-dir: "core-services/egov-otp/src/main/resources/db"
+        image-name: "egov-otp-db"
+
+  - name: "builds/Digit-Core/core-services/egov-persister"
+    build:
+      - work-dir: "core-services/egov-persister"
+        image-name: "egov-persister"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+
+  - name: "builds/Digit-Core/core-services/egov-pg-service"
+    build:
+      - work-dir: "core-services/egov-pg-service"
+        image-name: "egov-pg-service"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+      - work-dir: "core-services/egov-pg-service/src/main/resources/db"
+        image-name: "egov-pg-service-db"
+
+  - name: "builds/Digit-Core/core-services/egov-searcher"
+    build:
+      - work-dir: "core-services/egov-searcher"
+        image-name: "egov-searcher"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+
+  - name: "builds/Digit-Core/core-services/egov-telemetry"
+    build:
+      - work-dir: "core-services/egov-telemetry"
+        image-name: "egov-telemetry"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+
+  - name: "builds/Digit-Core/core-services/egov-user"
+    build:
+      - work-dir: "core-services/egov-user"
+        image-name: "egov-user"
+        dockerfile: "build/maven-java8-jdk21/Dockerfile"
+      - work-dir: "core-services/egov-user/src/main/resources/db"
+        image-name: "egov-user-db"
+
+  - name: "builds/Digit-Core/core-services/egov-user-event"
+    build:
+      - work-dir: "core-services/egov-user-event"
+        image-name: "egov-user-event"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+      - work-dir: "core-services/egov-user-event/src/main/resources/db"
+        image-name: "egov-user-event-db"
+
+  - name: "builds/Digit-Core/core-services/egov-workflow-v2"
+    build:
+      - work-dir: "core-services/egov-workflow-v2"
+        image-name: "egov-workflow-v2"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+      - work-dir: "core-services/egov-workflow-v2/src/main/resources/db"
+        image-name: "egov-workflow-v2-db"
+
+  - name: "builds/Digit-Core/core-services/egov-document-uploader"
+    build:
+      - work-dir: "core-services/egov-document-uploader"
+        image-name: "egov-document-uploader"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+      - work-dir: "core-services/egov-document-uploader/src/main/resources/db"
+        image-name: "egov-document-uploader-db"
+
+  - name: "builds/Digit-Core/core-services/national-dashboard-ingest"
+    build:
+      - work-dir: "core-services/national-dashboard-ingest"
+        image-name: "national-dashboard-ingest"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+      - work-dir: "core-services/national-dashboard-ingest/src/main/resources/db"
+        image-name: "national-dashboard-ingest-db"
+
+  - name: "builds/Digit-Core/core-services/national-dashboard-kafka-pipeline"
+    build:
+      - work-dir: "core-services/national-dashboard-kafka-pipeline"
+        image-name: "national-dashboard-kafka-pipeline"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+
+  - name: "builds/Digit-Core/core-services/egov-survey-services"
+    build:
+      - work-dir: "core-services/egov-survey-services"
+        image-name: "egov-survey-services"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+      - work-dir: "core-services/egov-survey-services/src/main/resources/db"
+        image-name: "egov-survey-services-db"
+
+
+  - name: "builds/Digit-Core/core-services/report"
+    build:
+      - work-dir: "core-services/report"
+        image-name: "report"
+        dockerfile: "build/maven-jdk21/Dockerfile"   
+
+  - name: "builds/Digit-Core/core-services/tenant"
+    build:
+      - work-dir: "core-services/tenant"
+        image-name: "tenant"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+      - work-dir: "core-services/tenant/src/main/resources/db"
+        image-name: "tenant-db"
+
+  - name: "builds/Digit-Core/core-services/user-otp"
+    build:
+      - work-dir: "core-services/user-otp"
+        image-name: "user-otp"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+
+  - name: "builds/Digit-Core/core-services/zuul"
+    build:
+      - work-dir: "core-services/zuul"
+        image-name: "zuul"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+
+  - name: "builds/Digit-Core/core-services/gateway"
+    build:
+      - work-dir: "core-services/gateway"
+        image-name: "gateway"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+
+  - name: "builds/Digit-Core/core-services/internal-gateway"
+    build:
+      - work-dir: "core-services/internal-gateway"
+        image-name: "internal-gateway"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+
+  - name: "builds/Digit-Core/core-services/internal-gateway-scg"
+    build:
+      - work-dir: "core-services/internal-gateway-scg"
+        image-name: "internal-gateway-scg"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+
+  - name: "builds/Digit-Core/core-services/pdf-service"
+    build:
+      - work-dir: "core-services/pdf-service"
+        image-name: "pdf-service"
+        dockerfile: "core-services/pdf-service/Dockerfile"
+      - work-dir: "core-services/pdf-service/migration"
+        image-name: "pdf-service-db"
+        
+  - name: "builds/Digit-Core/core-services/telemetry/egov-telemetry-kafka-streams"
+    build:
+      - work-dir: "core-services/egov-telemetry/egov-telemetry-kafka-streams"
+        image-name: "egov-telemetry-kafka-streams"
+
+  - name: "builds/Digit-Core/core-services/telemetry/egov-telemetry-batch-process"
+    build:
+      - work-dir: "core-services/egov-telemetry/egov-telemetry-batch-process"
+        image-name: "egov-telemetry-batch-process"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+  
+  - name: "builds/Digit-Core/core-services/egov-url-shortening"
+    build:
+      - work-dir: "core-services/egov-url-shortening"
+        image-name: "egov-url-shortening"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+      - work-dir: "core-services/egov-url-shortening/src/main/resources/db"
+        image-name: "egov-url-shortening-db"
+  
+  - name: "builds/Digit-Core/core-services/chatbot"
+    build:
+      - work-dir: "core-services/chatbot"
+        image-name: "chatbot"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+      - work-dir: "core-services/chatbot/src/main/resources/db"
+        image-name: "chatbot-db"
+        
+  - name: "builds/Digit-Core/core-services/http-to-kafka-connector"
+    build:
+      - work-dir: "core-services/http-to-kafka-connector"
+        image-name: "whatsapp-webhook"
+
+  - name: "builds/Digit-Core/core-services/egov-user-chatbot"
+    build:
+      - work-dir: "core-services/egov-user"
+        image-name: "egov-user-chatbot"
+        dockerfile: "build/maven-java8-jdk21/Dockerfile"
+
+  - name: "builds/Digit-Core/core-services/mailbot"
+    build:
+      - work-dir: "core-services/mailbot"
+        image-name: "mailbot"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+
+  - name: "builds/Digit-Core/core-services/libraries/enc-client"
+    build:
+      - work-dir: "core-services/libraries/enc-client"
+        image-name: "enc-client"
+
+  - name: "builds/Digit-Core/core-services/libraries/mdms-client"
+    build:
+      - work-dir: "core-services/libraries/mdms-client"
+        image-name: "mdms-client"
+
+
+  - name: "builds/Digit-Core/core-services/libraries/tracer"
+    build:
+      - work-dir: "core-services/libraries/tracer"
+        image-name: "tracer"
+        
+  - name: "builds/Digit-Core/core-services/libraries/digit-client"
+    build:
+      - work-dir: "core-services/libraries/digit-client"
+        image-name: "digit-client"      
+
+  - name: "builds/Digit-Core/core-services/libraries/digit-models"
+    build:
+      - work-dir: "core-services/libraries/digit-models"
+        image-name: "digit-models"
+
+  - name: "builds/Digit-Core/core-services/libraries/services-common"
+    build:
+      - work-dir: "core-services/libraries/services-common"
+        image-name: "services-common"
+
+  - name: "builds/Digit-Core/core-services/libraries/notify-spi"
+    build:
+      - work-dir: "core-services/libraries/notify-spi"
+        image-name: "notify-spi"
+
+  - name: "builds/Digit-Core/core-services/nlp-engine"
+    build:
+      - work-dir: "core-services/nlp-engine"
+        image-name: "nlp-engine"
+        dockerfile: "nlp-engine/Dockerfile"
+
+  - name: "builds/Digit-Core/core-services/xstate-chatbot"
+    build:
+      - work-dir: "core-services/xstate-chatbot/nodejs"
+        image-name: "xstate-chatbot"
+      - work-dir: "core-services/xstate-chatbot/nodejs/db"
+        image-name: "xstate-chatbot-db"
+
+  - name: "builds/Digit-Core/core-services/xstate-webchat"
+    build:
+      - work-dir: "core-services/xstate-webchat/nodejs"
+        image-name: "xstate-webchat"
+      - work-dir: "core-services/xstate-webchat/nodejs/db"
+        image-name: "xstate-webchat-db"
+
+  - name: "builds/Digit-Core/accelerators/inbox"
+    build:
+      - work-dir: "accelerators/inbox"
+        image-name: "inbox"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+
+  - name: "builds/Digit-Core/accelerators/gateway-kubernetes-discovery"
+    build:
+      - work-dir: "accelerators/gateway-kubernetes-discovery"
+        image-name: "gateway-kubernetes-discovery"
+
+  - name: "builds/Digit-Core/accelerators/pgr-services"
+    build:
+      - work-dir: "accelerators/pgr-services"
+        image-name: "pgr-services"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+      - work-dir: "accelerators/pgr-services/src/main/resources/db"
+        image-name: "pgr-services-db"
+
+  - name: "builds/Digit-Core/core-services/service-request"
+    build:
+      - work-dir: "core-services/service-request"
+        image-name: "service-request"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+      - work-dir: "core-services/service-request/src/main/resources/db"
+        image-name: "service-request-db"
+
+  - name: "builds/Digit-Core/core-services/default-data-handler"
+    build:
+      - work-dir: "core-services/default-data-handler"
+        image-name: "default-data-handler"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+
+  - name: "builds/Digit-Core/core-services/TenantManagement"
+    build:
+      - work-dir: "core-services/TenantManagement"
+        image-name: "tenant-management"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+      - work-dir: "core-services/TenantManagement/src/main/resources/db"
+        image-name: "tenant-management-db"
+
+  - name: "builds/Digit-Core/core-services/keycloak-spi"
+    build:
+      - work-dir: "core-services/keycloak-spi"
+        image-name: "keycloak"
+        dockerfile: "core-services/keycloak-spi/Dockerfile"
+  
+  # PGR AI chatbot
+  - name: "builds/Digit-Core/accelerators/pgr-ai-chatbot"
+    build:
+      - work-dir: "accelerators/pgr-ai-chatbot"
+        image-name: "pgr-ai-chatbot"
+        dockerfile: "accelerators/pgr-ai-chatbot/ops/Dockerfile"
+    
+
+# frontend
+  - name: builds/Digit-Core/accelerators/workbench-ui
+    build:
+      - work-dir: frontend/micro-ui/
+        dockerfile: frontend/micro-ui/web/workbench/Dockerfile
+        image-name: workbench-ui
+        
+  - name: builds/Digit-Core/accelerators/storybook-svg
+    build:
+    - work-dir: frontend/micro-ui/web/micro-ui-internals/packages/svg-components/
+      dockerfile: frontend/micro-ui/web/micro-ui-internals/packages/svg-components/docker/Dockerfile
+      image-name: storybook-svg
+      
+  - name: builds/Digit-Core/accelerators/storybook
+    build:
+    - work-dir: frontend/micro-ui/web/micro-ui-internals/packages/components-core/
+      dockerfile: frontend/micro-ui/web/micro-ui-internals/packages/components-core/docker/Dockerfile
+      image-name: storybook
+
+  - name: builds/Digit-Core/accelerators/digit-ui
+    build:
+      - work-dir: frontend/micro-ui/
+        dockerfile: frontend/micro-ui/web/docker/Dockerfile
+        image-name: digit-ui
+
+#lts-demo-birth-service
+  - name: "builds/Digit-Core/accelerators/egov-birth-service"
+    build:
+      - work-dir: "accelerators/egov-birth-service"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+        image-name: "egov-birth-service"
+      - work-dir: "accelerators/egov-birth-service/src/main/resources/db"
+        image-name: "egov-birth-service-db"
+
+  - name: "builds/Digit-Core/accelerators/sunbirdrc-credential-service"
+    build:
+      - work-dir: "accelerators/sunbirdrc-credential-service"
+        image-name: "sunbirdrc-credential-service"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+      - work-dir: "accelerators/sunbirdrc-credential-service/src/main/resources/db"
+        image-name: "sunbirdrc-credential-service-db"
+
+  - name: "builds/Digit-Core/accelerators/qr-scanner-ui"
+    build:
+      - work-dir: "accelerators/qr-scanner-ui"
+        image-name: "qr-scanner-ui"
+        dockerfile: "accelerators/qr-scanner-ui/Dockerfile"
+
+#Accelerators
+  - name: "builds/Digit-Core/accelerators/im-services-analytics"
+    build:
+      - work-dir: "accelerators/im-services-analytics"
+        image-name: "im-services-analytics"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+
+  - name: "builds/Digit-Core/accelerators/vault-enc-service"
+    build:
+      - work-dir: "accelerators/vault-enc-service"
+        image-name: "vault-enc-service"
+        dockerfile: "build/maven-jdk21/Dockerfile"
+      - work-dir: "accelerators/vault-enc-service/src/main/resources/db"
+        image-name: "vault-enc-service-db"

--- a/build/maven-java8-jdk21/Dockerfile
+++ b/build/maven-java8-jdk21/Dockerfile
@@ -1,0 +1,78 @@
+# JDK 8→21 hybrid: compile with JDK 8, run on JDK 21.
+# Use this for services on Spring Boot 1.5/2.x that cannot be recompiled
+# for JDK 17+ but benefit from JDK 21's cgroup v2 fix and memory improvements.
+#
+# JDK 21 fixes cgroup v2 CPU detection (JDK-8281181), auto-sizes heap/threads
+# from container limits, and runs Java 8 bytecode natively.
+#
+# Spring Boot 1.5 needs two runtime patches for JDK 21:
+#   1. JAXB API + runtime (removed from JDK 11)
+#   2. --add-opens flags for internal JDK module access
+
+# ──────────────── BUILD STAGE ────────────────
+FROM egovio/maven:3.9.6-amazoncorretto-8-debian AS build
+ARG WORK_DIR
+WORKDIR /app
+
+COPY ${WORK_DIR}/pom.xml       ./pom.xml
+COPY build/maven-java8-jdk21/start.sh ./start.sh
+COPY ${WORK_DIR}/src           ./src
+
+RUN mvn -B -f pom.xml package -DskipTests
+
+# ──────────── JAXB PATCH STAGE ─────────────
+FROM eclipse-temurin:21-jdk-alpine AS patcher
+RUN apk add --no-cache curl
+WORKDIR /patch
+
+COPY --from=build /app/target/*.jar ./app.jar
+
+# Download JAXB API + implementation (removed from JDK 11+)
+RUN curl -sL -o jaxb-api.jar https://repo1.maven.org/maven2/javax/xml/bind/jaxb-api/2.3.1/jaxb-api-2.3.1.jar && \
+    curl -sL -o javax.activation.jar https://repo1.maven.org/maven2/javax/activation/javax.activation-api/1.2.0/javax.activation-api-1.2.0.jar && \
+    curl -sL -o jaxb-runtime.jar https://repo1.maven.org/maven2/org/glassfish/jaxb/jaxb-runtime/2.3.9/jaxb-runtime-2.3.9.jar && \
+    curl -sL -o txw2.jar https://repo1.maven.org/maven2/org/glassfish/jaxb/txw2/2.3.9/txw2-2.3.9.jar && \
+    curl -sL -o istack-commons-runtime.jar https://repo1.maven.org/maven2/com/sun/istack/istack-commons-runtime/3.0.12/istack-commons-runtime-3.0.12.jar && \
+    curl -sL -o stax-ex.jar https://repo1.maven.org/maven2/org/jvnet/staxex/stax-ex/1.8.1/stax-ex-1.8.1.jar
+
+# Inject JAXB jars into the fat JAR (jar uf0 preserves STORED entries)
+RUN mkdir -p BOOT-INF/lib && \
+    cp jaxb-api.jar javax.activation.jar jaxb-runtime.jar txw2.jar \
+       istack-commons-runtime.jar stax-ex.jar BOOT-INF/lib/ && \
+    jar uf0 app.jar \
+      BOOT-INF/lib/jaxb-api.jar \
+      BOOT-INF/lib/javax.activation.jar \
+      BOOT-INF/lib/jaxb-runtime.jar \
+      BOOT-INF/lib/txw2.jar \
+      BOOT-INF/lib/istack-commons-runtime.jar \
+      BOOT-INF/lib/stax-ex.jar
+
+# ─────────────── RUNTIME STAGE ───────────────
+FROM eclipse-temurin:21-jre-alpine
+
+RUN apk add --no-cache dos2unix
+
+WORKDIR /opt/egov
+
+COPY --from=patcher /patch/app.jar /opt/egov/app.jar
+COPY --from=build /app/start.sh /opt/egov/start.sh
+
+# CDS pre-dump: generate classlist then shared archive for faster startup.
+RUN timeout 30 java \
+      --add-opens java.base/java.lang=ALL-UNNAMED \
+      --add-opens java.base/java.lang.reflect=ALL-UNNAMED \
+      --add-opens java.base/java.util=ALL-UNNAMED \
+      -XX:DumpLoadedClassList=/opt/egov/app.classlist \
+      -jar /opt/egov/app.jar 2>/dev/null; true
+RUN java \
+      --add-opens java.base/java.lang=ALL-UNNAMED \
+      --add-opens java.base/java.lang.reflect=ALL-UNNAMED \
+      --add-opens java.base/java.util=ALL-UNNAMED \
+      -Xshare:dump \
+      -XX:SharedClassListFile=/opt/egov/app.classlist \
+      -XX:SharedArchiveFile=/opt/egov/app-cds.jsa \
+      -jar /opt/egov/app.jar 2>/dev/null; true
+
+RUN dos2unix /opt/egov/start.sh && chmod +x /opt/egov/start.sh
+
+CMD ["/opt/egov/start.sh"]

--- a/build/maven-java8-jdk21/Dockerfile
+++ b/build/maven-java8-jdk21/Dockerfile
@@ -28,12 +28,12 @@ WORKDIR /patch
 COPY --from=build /app/target/*.jar ./app.jar
 
 # Download JAXB API + implementation (removed from JDK 11+)
-RUN curl -sL -o jaxb-api.jar https://repo1.maven.org/maven2/javax/xml/bind/jaxb-api/2.3.1/jaxb-api-2.3.1.jar && \
-    curl -sL -o javax.activation.jar https://repo1.maven.org/maven2/javax/activation/javax.activation-api/1.2.0/javax.activation-api-1.2.0.jar && \
-    curl -sL -o jaxb-runtime.jar https://repo1.maven.org/maven2/org/glassfish/jaxb/jaxb-runtime/2.3.9/jaxb-runtime-2.3.9.jar && \
-    curl -sL -o txw2.jar https://repo1.maven.org/maven2/org/glassfish/jaxb/txw2/2.3.9/txw2-2.3.9.jar && \
-    curl -sL -o istack-commons-runtime.jar https://repo1.maven.org/maven2/com/sun/istack/istack-commons-runtime/3.0.12/istack-commons-runtime-3.0.12.jar && \
-    curl -sL -o stax-ex.jar https://repo1.maven.org/maven2/org/jvnet/staxex/stax-ex/1.8.1/stax-ex-1.8.1.jar
+RUN curl -fsSL -o jaxb-api.jar https://repo1.maven.org/maven2/javax/xml/bind/jaxb-api/2.3.1/jaxb-api-2.3.1.jar && \
+    curl -fsSL -o javax.activation.jar https://repo1.maven.org/maven2/javax/activation/javax.activation-api/1.2.0/javax.activation-api-1.2.0.jar && \
+    curl -fsSL -o jaxb-runtime.jar https://repo1.maven.org/maven2/org/glassfish/jaxb/jaxb-runtime/2.3.9/jaxb-runtime-2.3.9.jar && \
+    curl -fsSL -o txw2.jar https://repo1.maven.org/maven2/org/glassfish/jaxb/txw2/2.3.9/txw2-2.3.9.jar && \
+    curl -fsSL -o istack-commons-runtime.jar https://repo1.maven.org/maven2/com/sun/istack/istack-commons-runtime/3.0.12/istack-commons-runtime-3.0.12.jar && \
+    curl -fsSL -o stax-ex.jar https://repo1.maven.org/maven2/org/jvnet/staxex/stax-ex/1.8.1/stax-ex-1.8.1.jar
 
 # Inject JAXB jars into the fat JAR (jar uf0 preserves STORED entries)
 RUN mkdir -p BOOT-INF/lib && \
@@ -71,8 +71,21 @@ RUN java \
       -Xshare:dump \
       -XX:SharedClassListFile=/opt/egov/app.classlist \
       -XX:SharedArchiveFile=/opt/egov/app-cds.jsa \
-      -jar /opt/egov/app.jar 2>/dev/null; true
+      -jar /opt/egov/app.jar 2>/dev/null
 
 RUN dos2unix /opt/egov/start.sh && chmod +x /opt/egov/start.sh
+
+# Run unprivileged, matching the distroless :nonroot runtime that
+# build/maven/Dockerfile uses. Nothing writes to /opt/egov at runtime — the CDS
+# archive is read-only and logs go to stdout — so read access is sufficient.
+#
+# /tmp must be cleared first: the CDS pre-dump above boots the app as root,
+# which leaves root-owned artefacts there (e.g. logback's /tmp/spring.log and
+# hsperfdata_root). A non-root process cannot reopen those, and logback treats
+# that as a fatal configuration error.
+RUN find /tmp -mindepth 1 -delete \
+    && addgroup -S egov && adduser -S -G egov -h /opt/egov egov \
+    && chown -R egov:egov /opt/egov
+USER egov
 
 CMD ["/opt/egov/start.sh"]

--- a/build/maven-java8-jdk21/start.sh
+++ b/build/maven-java8-jdk21/start.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# JDK 21 auto-sizes heap from cgroup limits — no default -Xms/-Xmx needed.
+# Set JAVA_OPTS or JAVA_TOOL_OPTIONS via container environment if tuning is required.
+
+# CDS: use shared archive if it exists (pre-baked at image build time)
+CDS_OPTS=""
+if [ -f /opt/egov/app-cds.jsa ]; then
+    CDS_OPTS="-XX:SharedArchiveFile=/opt/egov/app-cds.jsa"
+fi
+
+# Spring Boot 1.5 uses internal JDK APIs via reflection.
+# These --add-opens flags are required for JDK 21 compatibility.
+ADD_OPENS="--add-opens java.base/java.lang=ALL-UNNAMED"
+ADD_OPENS="$ADD_OPENS --add-opens java.base/java.lang.reflect=ALL-UNNAMED"
+ADD_OPENS="$ADD_OPENS --add-opens java.base/java.util=ALL-UNNAMED"
+# Tomcat clears ObjectStreamClass caches via reflection on context stop.
+ADD_OPENS="$ADD_OPENS --add-opens java.base/java.io=ALL-UNNAMED"
+
+if [ x"${JAVA_ENABLE_DEBUG}" != x ] && [ "${JAVA_ENABLE_DEBUG}" != "false" ]; then
+    java_debug_args="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${JAVA_DEBUG_PORT:-5005}"
+fi
+
+exec java ${java_debug_args} ${ADD_OPENS} ${JAVA_OPTS} ${CDS_OPTS} ${JAVA_ARGS} -jar /opt/egov/app.jar

--- a/build/maven-jdk21/Dockerfile
+++ b/build/maven-jdk21/Dockerfile
@@ -1,0 +1,44 @@
+# JDK 21 runtime variant of build/maven/Dockerfile.
+# Use this for services on Spring Boot 3.x compiled with Java 17+.
+# Services on Spring Boot 1.5/2.x must continue using build/maven/Dockerfile.
+#
+# JDK 21 fixes cgroup v2 CPU detection (JDK-8281181), auto-sizes heap/threads
+# from container limits, and runs Java 17 bytecode natively (no recompilation).
+
+FROM egovio/maven:3.9.6-amazoncorretto-17 AS build
+ARG WORK_DIR
+WORKDIR /app
+
+# Copy project files
+COPY ${WORK_DIR}/pom.xml ./pom.xml
+COPY build/maven-jdk21/start.sh ./start.sh
+COPY ${WORK_DIR}/src ./src
+
+# Build the project
+RUN mvn -B -f /app/pom.xml package
+
+# Runtime image — JDK 21 on Alpine
+FROM eclipse-temurin:21-jre-alpine
+
+RUN apk add --no-cache dos2unix
+
+WORKDIR /opt/egov
+
+# Copy artifacts from the build stage
+COPY --from=build /app/target/*.jar /opt/egov/app.jar
+COPY --from=build /app/start.sh /opt/egov/start.sh
+
+# CDS pre-dump: generate classlist then shared archive for faster startup.
+# The app will attempt to start (no DB/Kafka available) — timeout kills it
+# after 30s, which is enough to load all classes for the classlist.
+RUN timeout 30 java -XX:DumpLoadedClassList=/opt/egov/app.classlist \
+      -jar /opt/egov/app.jar 2>/dev/null; true
+RUN java -Xshare:dump \
+      -XX:SharedClassListFile=/opt/egov/app.classlist \
+      -XX:SharedArchiveFile=/opt/egov/app-cds.jsa \
+      -jar /opt/egov/app.jar 2>/dev/null; true
+
+# Ensure the start script has correct line endings and is executable
+RUN dos2unix /opt/egov/start.sh && chmod +x /opt/egov/start.sh
+
+CMD ["/opt/egov/start.sh"]

--- a/build/maven-jdk21/Dockerfile
+++ b/build/maven-jdk21/Dockerfile
@@ -36,9 +36,22 @@ RUN timeout 30 java -XX:DumpLoadedClassList=/opt/egov/app.classlist \
 RUN java -Xshare:dump \
       -XX:SharedClassListFile=/opt/egov/app.classlist \
       -XX:SharedArchiveFile=/opt/egov/app-cds.jsa \
-      -jar /opt/egov/app.jar 2>/dev/null; true
+      -jar /opt/egov/app.jar 2>/dev/null
 
 # Ensure the start script has correct line endings and is executable
 RUN dos2unix /opt/egov/start.sh && chmod +x /opt/egov/start.sh
+
+# Run unprivileged, matching the distroless :nonroot runtime that
+# build/maven/Dockerfile uses. Nothing writes to /opt/egov at runtime — the CDS
+# archive is read-only and logs go to stdout — so read access is sufficient.
+#
+# /tmp must be cleared first: the CDS pre-dump above boots the app as root,
+# which leaves root-owned artefacts there (e.g. logback's /tmp/spring.log and
+# hsperfdata_root). A non-root process cannot reopen those, and logback treats
+# that as a fatal configuration error.
+RUN find /tmp -mindepth 1 -delete \
+    && addgroup -S egov && adduser -S -G egov -h /opt/egov egov \
+    && chown -R egov:egov /opt/egov
+USER egov
 
 CMD ["/opt/egov/start.sh"]

--- a/build/maven-jdk21/start.sh
+++ b/build/maven-jdk21/start.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# JDK 21 auto-sizes heap from cgroup limits — no default -Xms/-Xmx needed.
+# Set JAVA_OPTS or JAVA_TOOL_OPTIONS via container environment if tuning is required.
+
+# CDS: use shared archive if it exists (pre-baked at image build time)
+CDS_OPTS=""
+if [ -f /opt/egov/app-cds.jsa ]; then
+    CDS_OPTS="-XX:SharedArchiveFile=/opt/egov/app-cds.jsa"
+fi
+
+if [ x"${JAVA_ENABLE_DEBUG}" != x ] && [ "${JAVA_ENABLE_DEBUG}" != "false" ]; then
+    java_debug_args="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${JAVA_DEBUG_PORT:-5005}"
+fi
+
+exec java ${java_debug_args} ${JAVA_OPTS} ${CDS_OPTS} ${JAVA_ARGS} -jar /opt/egov/app.jar


### PR DESCRIPTION
Adds a parallel JDK 21 build path. **No existing file is modified** — this PR is six new files, 985 additions, 0 deletions. All Java 17 builds continue to use `build/maven/Dockerfile` exactly as before, and `build/build-config.yml`, `.github/workflows/build.yaml` and both `Jenkinsfile`s are untouched.

## New builders

Both are a **runtime-only** move to JDK 21 — nothing is recompiled for Java 21, so no `pom.xml` changes are needed.

| Builder | Compiles with | Runs on | For |
|---|---|---|---|
| `build/maven-jdk21/` | corretto 17 | `temurin:21-jre-alpine` | Spring Boot 3.x services |
| `build/maven-java8-jdk21/` | corretto 8 | `temurin:21-jre-alpine` | Spring Boot 1.5 (`egov-user`) |

Moving the runtime to JDK 21 fixes cgroup v2 CPU detection ([JDK-8281181](https://bugs.openjdk.org/browse/JDK-8281181)), enables container-aware heap sizing, and bakes a CDS archive for faster startup. The java8 variant additionally injects JAXB into the fat jar (removed from the JDK in 11+) and applies `--add-opens` for Spring Boot 1.5's reflective access.

Both builders were taken from the `maven-jdk21` branch.

## New config

`build/build-config-jdk21.yml` keeps the **same job names, work-dirs and image names** as `build/build-config.yml`, so the two are drop-in alternatives. Only the builder differs:

- 55 jobs → `build/maven-jdk21/Dockerfile`
- `egov-user` and `egov-user-chatbot` → `build/maven-java8-jdk21/Dockerfile`
- db/migration dirs, nodejs, frontend and service-owned Dockerfiles (`pdf-service`, `keycloak-spi`, `nlp-engine`, `qr-scanner-ui`, `pgr-ai-chatbot`) unchanged

`egov-user-chatbot` builds the `core-services/egov-user` source tree, so it gets the java8 builder even though `build-config.yml` currently has it on the Java 17 builder — otherwise it would produce an image that builds but crashes at startup.

Two duplicate entries in `build-config.yml` are omitted (documented in the file header), so this file has 78 jobs against 80:
- a second stranded copy of `core-services/egov-user-event` (exact duplicate)
- `accelerators/sample-services/backend/java/egov-birth-service`, which collides on the `egov-birth-service` image name and whose work-dir exists on no branch

## New workflow

`.github/workflows/build-jdk21.yml` is a copy of `build.yaml` with three changes: it reads `build-config-jdk21.yml`, defaults to `build/maven-jdk21/Dockerfile`, and tags images with a `jdk21` marker.

| Workflow | Tag |
|---|---|
| `build.yaml` | `egovio/<service>:<branch>-<hash>` |
| `build-jdk21.yml` | `egovio/<service>:<branch>-jdk21-<hash>` |

Both can run on the same commit without overwriting each other.

## Verification

Both builders were built and run against real dependencies (Postgres 14, Redis 7, stub MDMS) on kernel 7.0.0, cgroup v2, 12-CPU host.

| Service | Builder | Runtime | Bytecode | Startup | Health | Runs as |
|---|---|---|---|---|---|---|
| `egov-otp` | `maven-jdk21` | JDK 21.0.12 | 61 (Java 17) | 6.7s | `HTTP 200` | `uid=100(egov)` |
| `egov-user` | `maven-java8-jdk21` | JDK 21.0.12 | 52 (Java 8) | 7.4s | `HTTP 200`, `status:UP` | `uid=100(egov)` |

Spring Boot 1.5 boots cleanly on JDK 21 with the JAXB injection and `--add-opens` in place. CDS archive applied at runtime in both. Zero permission or JDK 21 compatibility errors (`InaccessibleObjectException`, `NoClassDefFoundError`, `UnsupportedClassVersionError`).

Also verified: the `yq` resolve step using the exact yq 4.30.8 query the workflow runs, correct per-service builder mapping for all 43 dropdown options, and the workflow parsing to the intended 3-stage DAG.

## Benchmark against #1240's claims

[#1240](https://github.com/egovernments/Digit-Core/pull/1240) is where these builders originate, and it makes specific performance claims. I re-measured them here. **Most did not reproduce on the current JDK 17 patch level.**

### cgroup v2 CPU detection (JDK-8281181)

The stated rationale is that JDK 17 sees all host CPUs instead of container limits. Comparing the image the current builder actually ships against the new one, `OSContainer::active_processor_count` on a 12-CPU host:

| Limit mode | distroless java17 (**17.0.18**) | temurin 21 (**21.0.12**) |
|---|---|---|
| `--cpus=2` (cpu.max quota) | 2 | 2 |
| `--cpu-shares=512`, no quota | 12 | 12 |
| `--cpuset-cpus=0,1` | 2 | 2 |

**Identical.** JDK-8281181 is already backported into 17.0.18, so this is no longer a differentiator — the claim likely held against an older 17.0.x. Note both JDKs report all 12 CPUs when only CPU *shares* are set (k8s `requests` without `limits`); JDK 21 does not fix that, since it is correct cgroup behaviour rather than a bug.

### Threads and memory at idle

Identical limits (`--cpus=2 --memory=512m`), measured 20s after startup:

| Service | Builder | Threads | RSS | % of limit |
|---|---|---|---|---|
| `egov-otp` | `build/maven` (JDK 17) | 39 | 208 MiB | 43.7% |
| `egov-otp` | `build/maven-jdk21` | **38** | **198 MiB** | **35.4%** |
| `egov-user` | `build/maven-java8` (JDK 8) | 28 | 201 MiB | 36.3% |
| `egov-user` | `build/maven-java8-jdk21` | **31** | **172 MiB** | **29.9%** |

RSS improves by 5% (`egov-otp`) and 14% (`egov-user`) — real but far short of #1240's "461 MiB → 184 MiB". Thread counts are flat, not the claimed "50-60 → ~15-34"; `egov-user` actually gained 3 threads.

Caveat on the `egov-user` row: `build/maven-java8/start.sh` forces `-Xmx64m -Xms64m` while `maven-java8-jdk21/start.sh` sets no default heap, so part of that 14% is the heap-flag change rather than the JDK itself.

### OOM survival and startup

| Check | Result |
|---|---|
| All four variants at `--memory=256m` | all survived, `OOMKilled=false` — no OOM difference reproduced |
| Startup, `egov-otp` 17 → 21 | 5.69s → 5.79s / 5.29s → 5.12s (within noise) |
| Startup, `egov-user` 8 → 21 | 5.94s → 6.26s / 6.54s → 6.28s (within noise) |

CDS shrinks class-loading work but did not produce a measurable wall-clock win at this scale.

### Cost

| Image | Size |
|---|---|
| `egov-otp` on `build/maven` (distroless) | 142 MB |
| `egov-otp` on `build/maven-jdk21` | **207 MB** (+46%) |
| `egov-user` on `build/maven-java8` | 143 MB |
| `egov-user` on `build/maven-java8-jdk21` | **169 MB** (+18%) |

The increase is the ~25 MB baked CDS archive plus alpine+temurin JRE being heavier than distroless.

### Reading of the results

The JDK 21 path is safe and works — every service tested starts, serves traffic and is healthy — and it gives a modest idle-memory improvement. But on JDK 17.0.18 the original cgroup rationale no longer applies, thread counts do not improve, startup is unchanged, and images get meaningfully larger. Worth weighing before migrating all 55 services.

These numbers come from a 12-CPU dev host with a stubbed MDMS, not the 8 vCPU / 16 GB k8s VM #1240 measured on, and I could not reproduce its ramp-2vu / ramp-300vu load tests or the end-to-end PGR flow. Differences in JAVA_OPTS from k8s manifests could also account for part of the gap.

## Notes for reviewers

- **CodeRabbit review addressed** in `6636c32`: both new Dockerfiles now run as a non-root `egov` user (they inherited root from `eclipse-temurin:21-jre-alpine`, whereas `build/maven/Dockerfile` uses distroless `:nonroot`), the six JAXB downloads use `curl -fsSL`, and `; true` is dropped from the `-Xshare:dump` step. The one rejected finding was adding `egov-user-chatbot` to the workflow dropdown — the workflow derives `WORK_DIR` from the service name and `core-services/egov-user-chatbot` does not exist, so it would fail at `COPY`.
- Making the builders non-root required clearing `/tmp` before dropping privileges: the CDS pre-dump boots the app as root, baking a root-owned `/tmp/spring.log` into the image that a non-root process cannot reopen, which logback treats as fatal.
- `build/maven-jdk21/Dockerfile` runs `mvn package` **with** tests, unlike `build/maven/Dockerfile` which uses `-DskipTests`. Inherited from the `maven-jdk21` branch; flagging as it will slow CI and can fail builds that `build.yaml` would pass.
- Nothing reads `build-config-jdk21.yml` on the Jenkins side — `Jenkinsfile` still hardcodes `./build/build-config.yml` and was deliberately left alone. Only the new GitHub Actions workflow uses the new config.
- Only `egov-otp` and `egov-user` were runtime-tested. The other 53 services on the JDK 21 path are untested, including under the new non-root user — a service writing outside stdout or `/tmp` could need attention.
- These three fixes now diverge from the `maven-jdk21` branch copies of both Dockerfiles, which still carry the root-user and CDS-masking issues.

## Summary by CodeRabbit

- **New Features**
  - Added JDK 21 build and deployment support for application services.
  - Added multi-architecture container image builds for amd64 and arm64.
  - Added optional database and migration image publishing where applicable.
  - Added support for running Java 8-compatible applications on JDK 21.
  - Added configurable startup options, including remote debugging support.
  - Added generated image tags and build details to workflow summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
