### PR TITLE
fix: handle null additionaldetails/geometry in BoundaryEntityRowMapper (#1389)

### DIFF
--- a/core-services/boundary-service/src/main/java/digit/repository/rowmapper/BoundaryEntityRowMapper.java
+++ b/core-services/boundary-service/src/main/java/digit/repository/rowmapper/BoundaryEntityRowMapper.java
@@ -24,33 +24,41 @@ public class BoundaryEntityRowMapper implements ResultSetExtractor<List<Boundary
     }
 
     @Override
-    public List<Boundary> extractData(ResultSet resultSet) throws SQLException , DataAccessException {
+    public List<Boundary> extractData(ResultSet resultSet) throws SQLException, DataAccessException {
 
         List<Boundary> boundaryList = new ArrayList<>();
 
         while (resultSet.next()) {
 
-            AuditDetails auditDetails = AuditDetails.builder().createdBy(resultSet.getString("createdby")).
-                    createdTime(resultSet.getLong("createdtime")).
-                    lastModifiedBy(resultSet.getString("lastmodifiedby")).
-                    lastModifiedTime(resultSet.getLong("lastmodifiedtime")).build();
+            AuditDetails auditDetails = AuditDetails.builder()
+                    .createdBy(resultSet.getString("createdby"))
+                    .createdTime(resultSet.getLong("createdtime"))
+                    .lastModifiedBy(resultSet.getString("lastmodifiedby"))
+                    .lastModifiedTime(resultSet.getLong("lastmodifiedtime"))
+                    .build();
 
             Boundary boundary;
             try {
+                // Safely read JSON strings, handling potential NULLs from the database
+                String geometryStr = resultSet.getString("geometry");
+                String additionalDetailsStr = resultSet.getString("additionaldetails");
+
                 boundary = Boundary.builder()
                         .id(resultSet.getString("id"))
                         .code(resultSet.getString("code"))
                         .auditDetails(auditDetails)
-                        .geometry(mapper.readTree(resultSet.getString("geometry")))
-                        .additionalDetails(mapper.readTree(resultSet.getString("additionaldetails")))
+                        // Parse only if not null, otherwise leave as null
+                        .geometry(geometryStr != null ? mapper.readTree(geometryStr) : null)
+                        .additionalDetails(additionalDetailsStr != null ? mapper.readTree(additionalDetailsStr) : null)
                         .tenantId(resultSet.getString("tenantid"))
                         .build();
             } catch (JsonProcessingException e) {
-                throw new CustomException("JSON_PARSE_ERROR" , "Failed to parse either additional details or geometry json");
+                throw new CustomException("JSON_PARSE_ERROR", "Failed to parse either additional details or geometry json");
             }
 
             boundaryList.add(boundary);
         }
         return boundaryList;
     }
+
 }

--- a/core-services/boundary-service/src/test/java/digit/repository/rowmapper/BoundaryEntityRowMapperTest.java
+++ b/core-services/boundary-service/src/test/java/digit/repository/rowmapper/BoundaryEntityRowMapperTest.java
@@ -1,0 +1,84 @@
+package digit.repository.rowmapper;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import digit.web.models.Boundary;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class BoundaryEntityRowMapperTest {
+
+    @Mock
+    private ResultSet resultSet;
+
+    @Mock
+    private ObjectMapper mapper;
+
+    @InjectMocks
+    private BoundaryEntityRowMapper rowMapper;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void shouldMapAdditionalDetailsAndGeometryAsNull_whenBothAreNullInDb() throws SQLException, JsonProcessingException {
+        when(resultSet.next()).thenReturn(true).thenReturn(false);
+
+        when(resultSet.getString("id")).thenReturn("b1");
+        when(resultSet.getString("code")).thenReturn("BND1");
+        when(resultSet.getString("geometry")).thenReturn(null);
+        when(resultSet.getString("additionaldetails")).thenReturn(null);
+        when(resultSet.getString("tenantid")).thenReturn("pg.citya");
+        when(resultSet.getString("createdby")).thenReturn("system");
+        when(resultSet.getLong("createdtime")).thenReturn(123456789L);
+        when(resultSet.getString("lastmodifiedby")).thenReturn("system");
+        when(resultSet.getLong("lastmodifiedtime")).thenReturn(123456789L);
+
+        List<Boundary> result = rowMapper.extractData(resultSet);
+
+        assertEquals(1, result.size());
+        assertNull(result.get(0).getGeometry());
+        assertNull(result.get(0).getAdditionalDetails());
+        assertEquals("b1", result.get(0).getId());
+
+        // Confirms readTree was never called on null input — mapper wasn't even touched
+        verify(mapper, never()).readTree(anyString());
+    }
+
+
+    @Test
+    void shouldParseAdditionalDetails_whenPresentInDb() throws Exception {
+        when(resultSet.next()).thenReturn(true).thenReturn(false);
+        when(resultSet.getString("id")).thenReturn("b2");
+        when(resultSet.getString("code")).thenReturn("BND2");
+        when(resultSet.getString("geometry")).thenReturn(null);
+        when(resultSet.getString("additionaldetails")).thenReturn("{\"key\":\"value\"}");
+        when(resultSet.getString("tenantid")).thenReturn("pg.citya");
+        when(resultSet.getString("createdby")).thenReturn("system");
+        when(resultSet.getLong("createdtime")).thenReturn(123456789L);
+        when(resultSet.getString("lastmodifiedby")).thenReturn("system");
+        when(resultSet.getLong("lastmodifiedtime")).thenReturn(123456789L);
+
+        JsonNode fakeNode = new ObjectMapper().readTree("{\"key\":\"value\"}");
+        when(mapper.readTree("{\"key\":\"value\"}")).thenReturn(fakeNode);
+
+        List<Boundary> result = rowMapper.extractData(resultSet);
+
+        assertNotNull(result.get(0).getAdditionalDetails());
+        assertEquals("value", result.get(0).getAdditionalDetails().get("key").asText());
+    }
+
+}

--- a/core-services/boundary-service/src/test/java/digit/repository/rowmapper/BoundaryEntityRowMapperTest.java
+++ b/core-services/boundary-service/src/test/java/digit/repository/rowmapper/BoundaryEntityRowMapperTest.java
@@ -81,4 +81,27 @@ class BoundaryEntityRowMapperTest {
         assertEquals("value", result.get(0).getAdditionalDetails().get("key").asText());
     }
 
+
+    @Test
+    void shouldParseGeometry_whenPresentInDb() throws Exception {
+        when(resultSet.next()).thenReturn(true).thenReturn(false);
+        when(resultSet.getString("id")).thenReturn("b3");
+        when(resultSet.getString("code")).thenReturn("BND3");
+        when(resultSet.getString("geometry")).thenReturn("{\"type\":\"Point\",\"coordinates\":[10,20]}");
+        when(resultSet.getString("additionaldetails")).thenReturn(null);
+        when(resultSet.getString("tenantid")).thenReturn("pg.citya");
+        when(resultSet.getString("createdby")).thenReturn("system");
+        when(resultSet.getLong("createdtime")).thenReturn(123456789L);
+        when(resultSet.getString("lastmodifiedby")).thenReturn("system");
+        when(resultSet.getLong("lastmodifiedtime")).thenReturn(123456789L);
+
+        JsonNode fakeGeometryNode = new ObjectMapper().readTree("{\"type\":\"Point\",\"coordinates\":[10,20]}");
+        when(mapper.readTree("{\"type\":\"Point\",\"coordinates\":[10,20]}")).thenReturn(fakeGeometryNode);
+
+        List<Boundary> result = rowMapper.extractData(resultSet);
+
+        assertNotNull(result.get(0).getGeometry());
+        assertEquals("Point", result.get(0).getGeometry().get("type").asText());
+    }
+
 }


### PR DESCRIPTION
Fixes #1389

## Root cause
`BoundaryEntityRowMapper.extractData()` called `mapper.readTree(...)` directly on
`additionaldetails` and `geometry` without checking for null. When either column
is `NULL` in the database, `resultSet.getString(...)` returns `null`, and
Jackson's `ObjectMapper.readTree(String)` throws
`IllegalArgumentException: argument "content" is null` — matching the reported
stack trace.

## Fix
Added a null check before calling `readTree` on both fields, so a `NULL` DB
value now maps to `null` on the `Boundary` object instead of throwing.

## Testing

Reproduced locally with a boundary row where `additionaldetails IS NULL`.

**Before fix** — `POST /boundary-service/boundary/_search?tenantId=1` throws:

<img width="655" height="442" alt="exception" src="https://github.com/user-attachments/assets/68541f29-6e51-41b2-8c66-56bb5d87b40c" />


*(Note: Spring returned this as a 400 here rather than a 500 — same underlying
`IllegalArgumentException: argument "content" is null` from the reported stack
trace, just wrapped differently by the exception handler in this run.)*


**After fix** — same request returns successfully:

<img width="345" height="528" alt="rectify-1" src="https://github.com/user-attachments/assets/c1483974-bfe6-42ca-8510-fb337d27224c" />


**Unit tests** — added `BoundaryEntityRowMapperTest` covering the null-safety
path and the normal-parsing path, both passing:

<img width="922" height="481" alt="rectify_testcase" src="https://github.com/user-attachments/assets/c08550fb-4b6f-4241-9629-54982f1066e1" />


This is my first contribution to DIGIT — happy to adjust the approach if there's
a preferred pattern I should follow instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of boundary records with missing geometry or additional details.
  * Null values are now preserved correctly instead of being processed as JSON, preventing errors when optional data is unavailable.
  * Valid additional details continue to be interpreted correctly, ensuring boundary information remains available when provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->